### PR TITLE
Add pytests function to dug shell script 

### DIFF
--- a/bin/dug
+++ b/bin/dug
@@ -228,6 +228,32 @@ test () {
 
 #############################################################
 ##
+## Python Tests: Run the python unit tests for DUG
+##
+#############################################################
+pytests () {
+  set -e
+
+  # Create the virtualenv if it doesn't exist already and
+  # install the required modules to the venv
+  if [[ ! -d $DUG_HOME/venv ]]; then
+    # TODO: Check that python3 exists before trying to use it
+    python3 -m venv $DUG_HOME/venv
+    source $DUG_HOME/venv/bin/activate
+    pip install -r $DUG_HOME/requirements.txt
+  fi
+
+  # NOTE: In certain scenarios we'll run the venv/bin/activate
+  # script twice, which is okay, since it's idempotent
+  source $DUG_HOME/venv/bin/activate
+  cd $DUG_HOME/dug/tests && python3 -m pytest
+  deactivate && cd $DUG_HOME
+
+  set +e
+}
+
+#############################################################
+##
 ## Query_API: Query the index via the search API.
 ##
 #############################################################

--- a/dug/README.md
+++ b/dug/README.md
@@ -169,11 +169,7 @@ Once the test is complete, a command line search shows the contents of the index
 
 
 ## Python Testing
-
-### Configuration
-1) Setup a virtual environment and install the required libs and modules from `requirements.txt`
-2) Clone `kgx` to the root of the repo and run `python setup.py install` inside it
-3) From within the `dug/dug` folder run `python -m pytest` to run unit tests
+* To run the python unit tests, type: `bin/dug pytests`
 
 
 ## Data Formats


### PR DESCRIPTION
Enables easier setup and execution of python unit tests for dug

to run, type: `bin/dug pytests`