### PR TITLE
Add cronjob and minikube instructions

### DIFF
--- a/bin/dug-docker
+++ b/bin/dug-docker
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#############################################################
+##
+## Index_tranql: Gather knowledge graphs from TranQL, create indices, and add to search engine.
+##
+#############################################################
+index_tranql () {
+    python -m dug.core --tagged-crawl $*
+}
+
+$*
+
+exit 0

--- a/kubernetes/annotate-cronjob.yaml
+++ b/kubernetes/annotate-cronjob.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: annotate
+spec:
+  schedule: "1 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: dug
+            image: heliumdatastage/dug:develop-latest
+            imagePullPolicy: Always
+            env:
+            - name: ELASTIC_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: ELASTIC_API_HOST
+            - name: ELASTIC_API_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: ELASTIC_API_PORT
+            - name: ELASTIC_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: ELASTIC_USER
+            - name: ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dug-secrets
+                  key: ELASTIC_PASSWORD
+            - name: NEO4J_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: NEO4J_HOST
+            - name: NEO4J_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: NEO4J_PORT
+            - name: NEO4J_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: NEO4J_USER
+            - name: NEO4J_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dug-secrets
+                  key: NEO4J_PASSWORD
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: REDIS_HOST
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: REDIS_PORT
+            - name: REDIS_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: dug-configmap
+                  key: REDIS_USER
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dug-secrets
+                  key: REDIS_PASSWORD
+            command: ["bin/dug-docker"]
+            args: ["index_tranql", "data/topmed_variables_v1.0.csv"]
+          restartPolicy: OnFailure

--- a/kubernetes/minikube/README.md
+++ b/kubernetes/minikube/README.md
@@ -1,0 +1,67 @@
+# Run DUG in minikube
+
+Reference: https://kubernetes.io/docs/tasks/tools/install-minikube/
+
+## Setup and start
+
+```
+minikube start --driver=virtualbox
+minikube status
+```
+
+## Delete
+```
+minikube delete
+```
+
+## Start DUG
+
+Create Namespace
+```
+kubectl create -f namespace.yaml
+```
+
+Create Storage Class
+```
+kubectl apply -n dug -f storageclass-minikube.yaml
+```
+
+Launch DUG
+```
+cd ..
+
+# Copy the secrets template file and modify or ignore this step and random
+# passwords will be set.  Check "create-dug-secret-out.log" for generated
+# passwords and delete the log to keep passwords (generated or set) safe.
+cp dug-secrets-template.properties dug-secrets.properties
+# Edit dug-secrets.properties and change passwords.
+
+cp dug-configmap-template.properties dug-configmap.properties
+# Edit dug-configmap.properties and change values if needed.
+
+# Ensure kubectl is configured for Kubernetes cluster.
+
+# Execute script to create configmap in cluster.
+NAMESPACE="dug" ./create-dug-configmap.sh
+
+# Execute script to create secrets in cluster.
+NAMESPACE="dug" ./create-dug-secrets.sh
+
+# Deploy the Dug stack to Kubernetes.
+kubectl apply -n dug -f stack.yaml
+```
+
+## Depoy cron job
+```
+kubectl apply -n dug -f ../annotate-cronjob.yaml
+```
+
+## Manually trigger cronjob
+```
+kubectl create job -n dug --from=cronjob/annotate annotate-manual-0710-2
+```
+
+## Port forward Dug to local
+```
+kubectl port-forward -n dug service/dug 5551:5551
+```

--- a/kubernetes/minikube/README.md
+++ b/kubernetes/minikube/README.md
@@ -23,7 +23,7 @@ kubectl create -f namespace.yaml
 
 Create Storage Class
 ```
-kubectl apply -n dug -f storageclass-minikube.yaml
+kubectl apply -n dug -f storageclass.yaml
 ```
 
 Launch DUG

--- a/kubernetes/minikube/namespace.yaml
+++ b/kubernetes/minikube/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dug

--- a/kubernetes/minikube/storageclass.yaml
+++ b/kubernetes/minikube/storageclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: dug-storage
+provisioner: k8s.io/minikube-hostpath


### PR DESCRIPTION
* `annotate-cronjob.yaml` should run `bin/dug-docker` once the Docker image is rebuilt to include that script. `bin/dug` runs `dev init` and tries to create the `env` files that are not necessary in the Docker container. `bin/dug-docker` is a quick way to create the cron job without having to make changes to `bin/dug`. Long term, it's probably better to make the changes to `bin/dug` so we don't have parallel files.
* `kubernetes/minikube/README.md` has the instructions to run DUG in minikube. The only thing needed other than the `stack.yaml` is the `storageclass` and `namespace` to be created. 
* The Docker image builds need to be fixed for the build to pull the correct GitHub branch. Right now, it's always pulling master.
[Here](https://github.com/helxplatform/dug/blob/master/docker/dug/Dockerfile#L21) is the code where we need to add the GitHub branch to be cloned:
```
        git clone https://github.com/helxplatform/dug.git && \
```

Right now, `annotate-cronjob.yaml` will run but it's not running correctly because of the issues with `bin/dug`. This is the log of what I got to run:
```
INFO:__main__:connected to elasticsearch
[core.py][            __init__] INFO: connected to elasticsearch
INFO:__main__:creating indices: ['test']
[core.py][        init_indices] INFO: creating indices: ['test']
INFO:__main__:result created index test: {'acknowledged': True, 'shards_acknowledged': True, 'index': 'test'}
[core.py][        init_indices] INFO: result created index test: {'acknowledged': True, 'shards_acknowledged': True, 'index': 'test'}
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0012735'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0012735'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031246'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031246'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031245'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031245'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031247'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0031247'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0002105'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0002105'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0002099'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0002099'
INFO:__main__:select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0012388'
[core.py][               crawl] INFO: select phenotypic_feature->disease from '/graph/gamma/quick' where phenotypic_feature='HP:0012388'
```