### PR TITLE
Change curie map to accomodate HP & UBERON ontologies, add anatomical…

### DIFF
--- a/dug/core.py
+++ b/dug/core.py
@@ -484,7 +484,10 @@ if __name__ == '__main__':
             "chem_to_disease": tql.QueryFactory(["chemical_substance", "disease"], source),
             #"chem_to_disease_pheno": tql.QueryFactory(["chemical_substance", "disease", "phenotypic_feature"], source),
             #"chem_to_gene_to_disease": tql.QueryFactory(["chemical_substance", "gene", "disease"], source),
-            "phen_to_anat": tql.QueryFactory(["phenotypic_feature", "anatomical_entity"], source)}
+            "phen_to_anat": tql.QueryFactory(["phenotypic_feature", "anatomical_entity"], source),
+            "anat_to_disease": tql.QueryFactory(["anatomical_entity", "disease"], source),
+            "anat_to_pheno": tql.QueryFactory(["anatomical_entity", "phenotypic_feature"], source)
+        }
 
         # List of identifiers to stay away from for now
         query_exclude_identifiers = ["CHEBI:17336"]

--- a/dug/tranql.py
+++ b/dug/tranql.py
@@ -80,10 +80,11 @@ class QueryFactory:
                   "drug_exposure", "biological_process", "anatomical_entity"]
 
     # List of curie prefixes that are valid for certain curie types
-    curie_map = {"disease": ["MONDO", "ORPHANET", "DOID", "HP"],
-                 "phenotypic_feature": ["HPO", "EFO"],
-                 "gene": ["HGNC"],
-                 "chemical_substance": ["CHEBI", "PUBCHEM"]}
+    curie_map = {"disease": ["MONDO", "ORPHANET", "DOID"],
+                 "phenotypic_feature": ["HP", "HPO", "EFO"],
+                 "gene": ["HGNC", "NCBIGene"],
+                 "chemical_substance": ["CHEBI", "PUBCHEM"],
+                 "anatomical_entity": ["UBERON"]}
 
     def __init__(self, question_graph, source, curie_index=0):
 


### PR DESCRIPTION
…_entity queries

As a result of these changes, we gain the following extra documents from TranQL:

- 6 HP answers (phenotypic_feature)
- 13 UBERON terms (anatomical_entity)

Due to Monarch instability (we think), we **lose** 1 MONDO term with these changes compared to previous (MONDO:0005010).


