### PR TITLE
Enable crawl/index to start from TranQL instead of files; remove KG answer filter

### DIFF
--- a/dug/annotate.py
+++ b/dug/annotate.py
@@ -8,6 +8,7 @@ import urllib
 import xml.etree.ElementTree as ET
 from kgx import NeoTransformer, JsonTransformer
 from neo4jrestclient.client import GraphDatabase
+import requests
 from requests_cache import CachedSession
 from typing import List, Dict
 import hashlib
@@ -466,6 +467,84 @@ class TOPMedStudyAnnotator:
                     "category" : metadata['type']
                 })
         return graph
+
+    def get_variables_from_tranql(self):
+        '''
+        This function returns the tagged variables,
+        including identifer information,
+        from TranQL.  It is the starting point for
+        indexing documents into ElasticSearch
+        '''
+
+        # Create a session and connect to TranQL
+        tranql_endpoint = "https://tranql.renci.org/tranql/query?dynamic_id_resolution=true&asynchronous=false"
+        headers = {
+            "accept" : "application/json",
+            "Content-Type" : "text/plain"
+        }
+        s = requests.Session()
+        s.headers.update(headers)
+        #TODO: Clean up the session object by bringing header, url, and data into attributes of obj
+
+        # Build TranQL Query
+        source = "/schema"
+        questions = [#"biological_entity",
+                     "abstract_entity",
+                     "clinical_modifier",
+                     "clinical_trial"]
+        query = f"select {'->'.join(questions)} from '{source}'"
+        single_query = query + f" where abstract_entity = 'TOPMED.TAG:51'"
+
+        # Put this in while loop to iterate until we are successful in connecting to TranQL
+        while True:
+            try:
+                response = s.post(url = tranql_endpoint,
+                            data = query)
+                if response.status_code is not 200:
+                    logging.error(f"Encountered error: {response.status_code}.  Trying again...")
+                    continue
+                break
+            except requests.ConnectionError as e:
+                logger.error (f"Encountered exception: {e}.  Trying again...")
+
+        # Build List of Dicts
+        response = response.json () # transform to JSON document if successful.
+        nodes = response['knowledge_graph']['nodes']
+        edges = response['knowledge_graph']['edges']
+        tags = list(filter(lambda x: x['id'].startswith("TOPMED.TAG"),nodes))
+        variables = list(filter(lambda x: x['id'].startswith("TOPMED.VAR"),nodes))
+        studies = list(filter(lambda x: x['id'].startswith("TOPMED.STUDY"),nodes))
+
+        # Annotate Tags w/ identifiers
+        for tag in tags:
+            tag['title'] = tag.pop('name')
+            tag['identifiers'] = {}
+            tag_edges = [edge for edge in edges if edge['source_id']==tag['id'] and not edge['target_id'].startswith('TOPMED.VAR')]
+            identifiers = [tag['target_id'] for tag in tag_edges]
+            for identifier in identifiers:
+                # Find identifers in node
+                value = [node for node in nodes if node['id'] == identifier][0] # finds single dictionary
+                if 'label' not in value:
+                    value['label'] = value.pop('name') # change 'name' to 'label' for downstream processing
+                tag['identifiers'][identifier] = value
+        
+        # TODO: Is it more efficient to get variables thru tags?
+
+        # Add studies and tag_pk to variables
+        for variable in variables:
+            # Rename
+            variable['variable_id'] = variable.pop('id')
+
+            # Grab from tags
+            associations = [edge['source_id'] for edge in edges if edge['target_id']==variable['variable_id']]
+            variable['tag_pk'] = next(filter(lambda x: x.startswith('TOPMED.TAG'), associations), "").split(":")[1]
+            variable['study_id'] = next(filter(lambda x: x.startswith('TOPMED.STUDY'), associations), "")
+
+            # Grab from studies - only linked to one study name
+            variable['study_name'] = [study['name'] for study in studies if study['id']==variable['study_id']][0]
+
+        # Return tags and variables
+        return variables, tags
 
 class GraphDB:
     def __init__(self, conf):

--- a/dug/core.py
+++ b/dug/core.py
@@ -473,8 +473,11 @@ if __name__ == '__main__':
         annotator = TOPMedStudyAnnotator(config=config)
 
         # Annotate tagged variables
-        variables, tags = annotator.load_tagged_variables(args.tagged)
-        tags = annotator.annotate(tags)
+        #variables, tags = annotator.load_tagged_variables(args.tagged)
+        #tags = annotator.annotate(tags)
+        
+        # Return tags and variables from TranQL
+        variables, tags = annotator.get_variables_from_tranql()
 
         source = "/graph/gamma/quick"
         queries = {


### PR DESCRIPTION
The `get_variables_from_tranql` function and associated edits allows for starting crawl/index from TranQL.  This helps to split out annotation and normalization, which must occur when starting crawl/index from files, from the crawl/index tasks in TranQL and Elasticsearch.  

This PR ensures that both pathways still work by using different flags passed to dug/core.py.  The difference is below:
**Crawl/Index from Files**
`python -m dug/core.py --tagged data/topmed_variables_v1.0.csv`

**Crawl/Index from TranQL**
`python -m dug/core.py --tranql`

This has implications for the deployment process - if we want a deployment in which we use TranQL as our starting point, the commands (--tranql flag) must reflect that.

**Finally**, the filtering for KG answers was removed; after a discussion, we don't yet know how this is calculated and we found that it was removing interesting answers and reducing our pool of synonyms.  For instance, searching "heart attack" (exact match) now brings back the myocardial infarction tag whereas in the previous deployment, the answer containing this disease and synonym was removed by the filter.