### PR TITLE
Adding synonym_service to config in ingest to avoid error

### DIFF
--- a/dug/ingest.py
+++ b/dug/ingest.py
@@ -21,6 +21,7 @@ def main ():
     config = {
         'annotator'      : "https://api.monarchinitiative.org/api/nlp/annotate/entities?min_length=4&longest_only=false&include_abbreviation=false&include_acronym=false&include_numbers=false&content=",
         'normalizer'     : "https://nodenormalization-sri.renci.org/get_normalized_nodes?curie=",
+        'synonym_service': "https://onto.renci.org/synonyms/",
         'password'       : os.environ['NEO4J_PASSWORD'],
         'username'       : 'neo4j',
         'db_url'         : db_url_default,


### PR DESCRIPTION
Added `synonym_service `key to the config dict in dug/ingest.py.  This was tested with a handful of variables and successfully ingests data into Neo4J database.

@cnbennett3 