### PR TITLE
specify index in search functions to only count results within specif…

### DIFF
--- a/dug/core.py
+++ b/dug/core.py
@@ -115,7 +115,7 @@ class Search:
 
         }
         body = json.dumps({'query': query})
-        total_items = self.es.count(body=body)
+        total_items = self.es.count(body=body, index=index)
         search_results = self.es.search(
             index=index,
             body=body,
@@ -142,7 +142,7 @@ class Search:
             },
         }
         body = json.dumps({'query': query})
-        total_items = self.es.count(body=body)
+        total_items = self.es.count(body=body, index=index)
         search_results = self.es.search(
             index=index,
             body=body,


### PR DESCRIPTION
…ied index.

Previously, the `total_items `field counted results from both of our indices; we never had to specify one because we only previously used one index, `test`.  The default behavior of `count `is to search across all indices unless specified, so to fix we specify the index.
