### PR TITLE
prefix_length removed from search_kg due to errors

### DIFF
--- a/dug/core.py
+++ b/dug/core.py
@@ -246,7 +246,7 @@ class Search:
         search_results.update({'total_items': total_items['count']})
         return search_results
 
-    def search_kg(self, index, unique_id, query, offset=0, size=None, fuzziness=1, prefix_length=3):
+    def search_kg(self, index, unique_id, query, offset=0, size=None, fuzziness=1):
         """
         Query type is now 'query_string'.
         query searches multiple fields
@@ -257,7 +257,6 @@ class Search:
             'query_string': {
                 'query': f'"{unique_id}" AND {query}',
                 'fuzziness': fuzziness,
-                'prefix_length': prefix_length,
                 'fields': ['search_targets', 'concept_id'],
                 'quote_field_suffix': ".exact"
             },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63300314/103034075-105ace80-4532-11eb-8b98-b32d6de7f2e1.png)
Error when using `prefix_length` with a query type of `query_string` because that query type does not support `prefix_length`.  end result was no Knowledge Graphs showing up in the UI.