### PR TITLE
Fix hanging concepts

### DIFF
--- a/dug/annotate.py
+++ b/dug/annotate.py
@@ -85,7 +85,7 @@ class TOPMedStudyAnnotator:
             "identifiers"          : {},
             "name"                 : variable.find ('name').text,
             "description"          : variable.find ('description').text.lower(),
-            "dataset_id"           : dataset_id,
+            "dataset_id"           : f"{dataset_id}.p{participant_set}",
             "dataset_name"         : "",
             "dataset_description"  : "",
             "study_id"             : f"{study_id}.p{participant_set}",

--- a/dug/core.py
+++ b/dug/core.py
@@ -833,10 +833,19 @@ class Search:
     
     def index_variables(self, variables, index):
         for variable in variables:
-            self.index_doc(
-                index=index,
-                doc=variable,
-                doc_id=variable['id'])
+            if not self.es.exists(index,variable['id']):
+                self.index_doc(
+                    index=index,
+                    doc=variable,
+                    doc_id=variable['id'])
+            else:
+                results = self.es.get(index, variable['id'])
+                identifiers = results['_source']['identifiers'] + variable['identifiers'] 
+                doc = {"doc" :{}}
+                doc['doc']['identifiers'] = identifiers
+                self.update_doc(index = index, doc = doc, doc_id = variable['id'])
+
+                
 
     def index_kg_answer(self, concept, index, curie_id, knowledge_graph, query_name, answer_node_ids):
         answer_synonyms = []

--- a/dug/core.py
+++ b/dug/core.py
@@ -154,6 +154,13 @@ class Search:
             index=index,
             id=doc_id,
             body=doc)
+    
+    def update_doc (self, index, doc, doc_id):
+        self.es.update (
+            index=index,
+            id=doc_id,
+            body=doc
+        )
 
     def search (self, index, query, offset=0, size=None, fuzziness=1):
         """


### PR DESCRIPTION
There is one main fix and one minor fix here:
**Minor:**
In annotate, we previously neglected to append the participant ID (e.g., p1) to the end of the dataset ID.  This branch fixes that issue.

**Major:**
We previously were getting concepts that had no variables attached.  We found that the reason for this was variable overwriting coming from the topmed variables.  These variables happened to overwrite some of the dbGaP variables AND overwrote themselves, as there are multiple instances of a given variable ID within the topmed_variables_dataset.  We opted to perform an update to the document when encountering an overwrite, in which unique identifiers would be appended to the document instead of overwriting all of it.  An example of a variable overwrite is below:

Coming into the index:
![image](https://user-images.githubusercontent.com/63300314/103163069-e66e0a00-47c6-11eb-8e13-fade24f38489.png)

Exists in the index:
![image](https://user-images.githubusercontent.com/63300314/103163072-eec64500-47c6-11eb-973e-4833b239ed65.png)

To ensure that after running the crawl of the dbGaP variables AND topmed_variables that there were no hanging variables, we ran the following code to loop through all concepts and ensure that at least one variable has this concept in its 'identifiers' field.

```
no_vars_concept_file = open("concepts_without_vars.json", "a+")
results = search.search_concepts_all(concepts_index)
    for result in results['hits']['hits']:
        concept = result['_id']
        new_result = search.search_variables_light("variables_index",concept)
        if not new_result['total_items']:
            print(new_result)
            no_vars_concept_file.write(f"{concept}-{args.crawl_file}\n")
```