### PR TITLE
Iss592 exact concept search

### DIFF
--- a/dug/core.py
+++ b/dug/core.py
@@ -194,14 +194,15 @@ class Search:
 
     def search_concepts (self, index, query, offset=0, size=None, fuzziness=1, prefix_length=3):
         """
-        Match query for simplicity, default OR
+        Changed to query_string for and/or and exact matches with quotations.
         """
         query = {
-            'multi_match': {
+            'query_string': {
                 'query' : query,
                 'fuzziness' : fuzziness,
-                'prefix_length': prefix_length,
-                'fields': ["name", "description", "search_terms","optional_terms"]
+                'fuzzy_prefix_length': prefix_length,
+                'fields': ["name", "description", "search_terms", "optional_terms"],
+                'quote_field_suffix': ".exact"
             },
         }
         body = json.dumps({'query': query})
@@ -226,7 +227,7 @@ class Search:
                 'must': [
                     {
                         "match": {
-                            "identifiers": concept
+                            "identifiers.keyword": concept
                         }
                     }
                 ],

--- a/dug/core.py
+++ b/dug/core.py
@@ -224,24 +224,19 @@ class Search:
         """
         query = {
             'bool': {
-                'must': [
-                    {
+                'must': {
                         "match": {
-                            "identifiers.keyword": concept
+                            "identifiers": concept
                         }
+                    },
+                'should': {
+                    'query_string': {
+                        "query": query,
+                        "fuzziness": fuzziness,
+                        "fuzzy_prefix_length": prefix_length,
+                        "default_field": "search_terms"
                     }
-                ],
-                'should': [
-                    {
-                        'match': {
-                            "search_terms": {
-                                "query": query,
-                                "fuzziness": fuzziness,
-                                "prefix_length": prefix_length,
-                            }
-                        }
-                    }
-                ]
+                }
             }
         }
         body = json.dumps({'query': query})
@@ -256,7 +251,7 @@ class Search:
         search_results.update({'total_items': total_items['count']})
         return search_results
 
-    def search_kg(self, index, unique_id, query, offset=0, size=None, fuzziness=1):
+    def search_kg(self, index, unique_id, query, offset=0, size=None, fuzziness=1, prefix_length=3):
         """
         In knowledge graph search seach, the concept MUST match the unique ID
         The query MUST match search_targets.  The updated query allows for
@@ -269,12 +264,12 @@ class Search:
                         "concept_id.keyword": unique_id
                         }
                     },
-                    {"match": {
-                        "search_targets": {
-		                    "query": query,
-		                    "fuzziness": fuzziness
+                    {'query_string': {
+                        "query": query,
+                        "fuzziness": fuzziness,
+                        "fuzzy_prefix_length": prefix_length,
+                        "default_field": "search_targets"
 		                }
-                    }
                     }
                 ]
             }


### PR DESCRIPTION
### Overview
This PR changes all of our three search functions (`search_concepts`, `search_variables`, `search_kg`) to use Elasticsearch's [query_string query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) instead of match queries which enables the functionality of exact search matching with quotations, and the search operators **AND** and **OR**.

### Behavior
I'll use heart attack as an example query.  Testing was done on a small subset of data, specifically all variables contained within `phs000810.v1.pht004715.v1.HCHS_SOL_Cohort_Subject_Phenotypes.data_dict.xml` and resulting annotations/TranQL calls to create concepts and KGs.

**Query 1: heart attack**
![image](https://user-images.githubusercontent.com/63300314/105241515-c6b6d100-5b3b-11eb-8433-859e8cb5af2b.png)

**Query 2: heart OR attack**
![image](https://user-images.githubusercontent.com/63300314/105241544-d2a29300-5b3b-11eb-8459-35d3c9762080.png)

This is expected behavior.  without logical operators, the default is OR.

**Query 3: "heart attack"**
![image](https://user-images.githubusercontent.com/63300314/105241651-e51ccc80-5b3b-11eb-9433-a05658917c2d.png)
Only myocardial infarction is returned, because it has the exact term 'heart attack' contained within one of its searched fields.

**Query 4: heart AND attack**
![image](https://user-images.githubusercontent.com/63300314/105242165-04b3f500-5b3c-11eb-8fcd-e2150f17bf36.png)


This is an interesting, but expected result - the second result was returned because both 'heart' and 'attack' are contained within the `optional_fields ` field of the clopidogrel concept.

### Fuzziness
Because we are using `query_string`, [we no longer have default fuzziness behavior](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness).  Instead, the user must add a tilde (~) plus a number, indicating the edit distance for fuzziness, to each term they want to 'fuzz-ify'.  We could make changes on the Python backend to implement fuzziness without the user having to explicitly specify it, however we didn't think fuzziness was that much of a benefit for all the code rework and edge case testing this would require.  So we will leave this without fuzziness unless a critical mass of users are requesting it.

![image](https://user-images.githubusercontent.com/63300314/105243233-c965f600-5b3c-11eb-94d4-5b470f612cbf.png)

![image](https://user-images.githubusercontent.com/63300314/105243306-df73b680-5b3c-11eb-920c-da5e7c75e350.png)
