### PR TITLE
Removing explicit BMT dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Babel==2.8.0
 backcall==0.1.0
 biolinkml==1.4.9
 bleach==3.1.1
-bmt==0.1.1
 cachetools==4.0.0
 certifi==2019.11.28
 CFGraph==0.2.1


### PR DESCRIPTION
This change updates the requirements.txt to remove the pinned dependency
to BMT 0.1.0. Dug was not using BMT anywhere. It is required by KGX,
which specifies BMT>=0.3.0.