### PR TITLE
Fixing error handling in integration test setup

### DIFF
--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -17,11 +17,14 @@ def is_elastic_up():
     ]
     username = os.environ.get('ELASTIC_USERNAME')
     password = os.environ.get('ELASTIC_PASSWORD')
-    es = Elasticsearch(
-        hosts=hosts,
-        http_auth=(username, password)
-    )
-    return es.ping()
+    try:
+        es = Elasticsearch(
+            hosts=hosts,
+            http_auth=(username, password)
+        )
+        return es.ping()
+    except Exception as _e:
+        return False
 
 
 @pytest.mark.skipif(not is_elastic_up(), reason="ElasticSearch is down")


### PR DESCRIPTION
This change adds some error handling to the search tests,
so that they don't blow up if certain env vars are not set.