### PR TITLE
Update search behavior

### DIFF
--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -85,7 +85,7 @@ class DugConcept:
         # Traverse set of identifiers to determine set of search terms
         search_terms = self.search_terms
         for ident_id, ident in self.identifiers.items():
-            search_terms.extend([ident.label, ident.description] + ident.search_text + ident.synonyms)
+            search_terms.extend(ident.search_text + ident.synonyms)
         self.search_terms = list(set(search_terms))
 
     def set_optional_terms(self):

--- a/src/dug/core/search.py
+++ b/src/dug/core/search.py
@@ -153,16 +153,99 @@ class Search:
 
     def search_concepts(self, index, query, offset=0, size=None, fuzziness=1, prefix_length=3):
         """
-        Changed to query_string for and/or and exact matches with quotations.
+        Changed to a long boolean match query to optimize search results
         """
         query = {
-            'query_string': {
-                'query': query,
-                'fuzziness': fuzziness,
-                'fuzzy_prefix_length': prefix_length,
-                'fields': ["name", "description", "search_terms", "optional_terms"],
-                'quote_field_suffix': ".exact"
-            },
+            "bool": {
+                "should": [
+                    {
+                        "match_phrase": {
+                            "name": {
+                                "query": query,
+                                "boost": 10
+                            }
+                        }
+                    },
+                    {
+                        "match_phrase": {
+                            "description": {
+                                "query": query,
+                                "boost": 6
+                            }
+                        }
+                    },
+                    {
+                        "match_phrase": {
+                            "search_terms": {
+                                "query": query,
+                                "boost": 8
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "name": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length,
+                                "operator": "and",
+                                "boost": 4
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "search_terms": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length,
+                                "operator": "and",
+                                "boost": 5
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "description": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length,
+                                "operator": "and",
+                                "boost": 3
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "description": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length,
+                                "boost": 2
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "search_terms": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length,
+                                "boost": 1
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "optional_terms": {
+                                "query": query,
+                                "fuzziness": fuzziness,
+                                "prefix_length": prefix_length
+                            }
+                        }
+                    }
+                ]
+            }
         }
         body = json.dumps({'query': query})
         total_items = self.es.count(body=body, index=index)


### PR DESCRIPTION
1. Fixed an issue that added 'name' and 'description' to the list of search terms, which unintentionally boosts the scores of certain results.  
2. Upgraded the search behavior to a long boolean match query that privileges exact matches on `name`, `description`, and `search_terms`, and de-emphasizes the `optional_terms`
3. explicit exact matching and 'AND/OR' boolean operators will no longer work with the match query.  Since we do not provide instructions to researchers using Dug, we felt this was prudent to bake this into the various clauses in the match query.