### PR TITLE
node normalization update to /1.1/ path

### DIFF
--- a/src/dug/config.py
+++ b/src/dug/config.py
@@ -39,7 +39,7 @@ class Config:
 
     # Normalizer config that will be passed to annotate.Normalizer constructor
     normalizer: dict = field(default_factory=lambda: {
-        "url": "https://nodenormalization-sri.renci.org/get_normalized_nodes?curie="
+        "url": "https://nodenormalization-sri.renci.org/1.1/get_normalized_nodes?curie="
     })
 
     # Synonym service config that will be passed to annotate.SynonymHelper constructor


### PR DESCRIPTION
Node normalization service has moved to 1.1/ as the root path. 
This PR modifies config in dug to align with that change