### PR TITLE
Add script to download all HEAL Platform MDS 

### DIFF
--- a/bin/get_heal_platform_mds_data_dicts.py
+++ b/bin/get_heal_platform_mds_data_dicts.py
@@ -1,0 +1,45 @@
+#
+# Script to download all HEAL Platform
+#
+# USAGE:
+#   HEAL_PLATFORM_MDS_ENDPOINT=https://healdata.org/mds/metadata python bin/get_heal_platform_mds_data_dicts.py [--output-dir OUTPUT_DIR]
+#
+# If no HEAL_PLATFORM_MDS_ENDPOINT is specified, we default to the production endpoint at https://healdata.org/mds/metadata
+# If no OUTPUT_DIR is specified, we default to the `data/heal_platform_mds` directory in this repository.
+#
+# This code was written with the assistance of ChatGPT (https://help.openai.com/en/articles/6825453-chatgpt-release-notes).
+#
+
+import click
+import logging
+
+# Turn on logging
+logging.basicConfig(level=logging.INFO)
+
+# Set up command line arguments.
+@click.command()
+@click.argument('output', type=click.Path(exists=False), required=True)
+def get_heal_platform_mds_data_dicts(output):
+    """
+    Retrieves files from the HEAL Platform Metadata Service (MDS) in a format that Dug can index,
+    which at the moment is the dbGaP XML format (as described in https://ftp.ncbi.nlm.nih.gov/dbgap/dtd/).
+
+    Creates the output directory, and then creates three directories in this directory:
+
+      - studies/[study ID (appl)].json: All the studies in the HEAL Platform MDS.
+
+      - datadicts/[data dictionary ID].json: All the data dictionaries in the HEAL Platform MDS.
+
+      - dbGaP/[data dictionary ID].xml: All the data dictionaries in the HEAL Platform MDS, converted into dbGaP XML format.
+
+    Since other projects also use the Gen3 Metadata Service (MDS), one of our lesser goals here is to
+    build code that could be quickly rewritten for other MDS schemas.
+
+    :param output: The output directory, which should not exist when the script is run.
+    """
+    print(f"Output directory: ${output}")
+
+
+# Run get_heal_platform_mds_data_dicts() if not used as a library.
+if __name__ == "__main__":
+    get_heal_platform_mds_data_dicts()

--- a/bin/get_heal_platform_mds_data_dicts.py
+++ b/bin/get_heal_platform_mds_data_dicts.py
@@ -10,16 +10,33 @@
 # This code was written with the assistance of ChatGPT (https://help.openai.com/en/articles/6825453-chatgpt-release-notes).
 #
 
+import os
 import click
 import logging
+
+# Some defaults.
+DEFAULT_MDS_ENDPOINT = 'https://healdata.org/mds/metadata'
 
 # Turn on logging
 logging.basicConfig(level=logging.INFO)
 
 # Set up command line arguments.
+def download_studies(studies_dir, mds_metadata_endpoint):
+    pass
+
+
+def download_data_dicts(data_dicts_dir, studies_dir, mds_metadata_endpoint):
+    pass
+
+
+def generate_dbgap_files(dbgap_dir, data_dict_ids, data_dicts_dir, studies, mds_metadata_endpoint):
+    return []
+
+
 @click.command()
-@click.argument('output', type=click.Path(exists=False), required=True)
-def get_heal_platform_mds_data_dicts(output):
+@click.argument('output', type=click.Path(), required=True) # TODO: restore exists=False once we're done developing.
+@click.option('--mds-metadata-endpoint', '--mds', default=DEFAULT_MDS_ENDPOINT, help='The MDS metadata endpoint to use, e.g. https://healdata.org/mds/metadata')
+def get_heal_platform_mds_data_dicts(output, mds_metadata_endpoint):
     """
     Retrieves files from the HEAL Platform Metadata Service (MDS) in a format that Dug can index,
     which at the moment is the dbGaP XML format (as described in https://ftp.ncbi.nlm.nih.gov/dbgap/dtd/).
@@ -30,14 +47,33 @@ def get_heal_platform_mds_data_dicts(output):
 
       - datadicts/[data dictionary ID].json: All the data dictionaries in the HEAL Platform MDS.
 
-      - dbGaP/[data dictionary ID].xml: All the data dictionaries in the HEAL Platform MDS, converted into dbGaP XML format.
+      - dbGaPs/[data dictionary ID].xml: All the data dictionaries in the HEAL Platform MDS, converted into dbGaP XML format.
 
     Since other projects also use the Gen3 Metadata Service (MDS), one of our lesser goals here is to
     build code that could be quickly rewritten for other MDS schemas.
 
     :param output: The output directory, which should not exist when the script is run.
     """
-    print(f"Output directory: ${output}")
+
+    # Create the output directory.
+    os.makedirs(output, exist_ok=True)
+
+    # Download studies from MDS endpoint.
+    studies_dir = os.path.join(output, 'studies')
+    os.makedirs(studies_dir, exist_ok=True)
+    studies = download_studies(studies_dir, mds_metadata_endpoint)
+
+    # Download data dictionaries from MDS endpoint.
+    data_dicts_dir = os.path.join(output, 'datadicts')
+    os.makedirs(data_dicts_dir, exist_ok=True)
+    data_dict_ids = download_data_dicts(data_dicts_dir, studies_dir, mds_metadata_endpoint)
+
+    # Generate dbGaP entries from the studies and the data dictionaries.
+    dbgap_dir = os.path.join(output, 'dbGaPs')
+    os.makedirs(dbgap_dir, exist_ok=True)
+    dbgap_filenames = generate_dbgap_files(dbgap_dir, data_dict_ids, data_dicts_dir, studies, mds_metadata_endpoint)
+
+    logging.info(f"Generated {len(dbgap_filenames)} dbGaP files for ingest in {dbgap_dir}.")
 
 
 # Run get_heal_platform_mds_data_dicts() if not used as a library.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ redis==4.4.2
 requests==2.28.2
 requests-cache==0.9.8
 six==1.16.0
+
+# Click for command line arguments
+click~=8

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ requests-cache==0.9.8
 six==1.16.0
 
 # Click for command line arguments
-click~=8
+# We use Click 7.0 because that's what one of the pinned packages above use.
+click~=7.0


### PR DESCRIPTION
Adds a `bin/get_heal_platform_mds_data_dicts.py` script that can be run directly to download HEAL Platform MDS studies and data dictionaries (probably into the `data/` directory), and then to convert these data dictionaries into dbGaP format so that Dug can ingest them.

Since get_heal_platform_mds_data_dicts.py accepts command line arguments, I've added the [Click](https://pypi.org/project/click/) package to Dug as well.

WIP: this only downloads the studies for now.