### PR TITLE
Add generic dbGaP downloader

### DIFF
--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -53,7 +53,7 @@ def download_dbgap_study(study_id, output_dir):
 
 @click.command()
 @click.argument('input_file')
-@click.option('--format', help='The format of the input file.', type=click.Choice(['CSV', 'TSV']), default='tsv', case_sensitive=False)
+@click.option('--format', help='The format of the input file.', type=click.Choice(['CSV', 'TSV']), default='tsv')
 @click.option('--field', help='The field name containing dbGaP study IDs or accession IDs.', default='dbgap_study_accession', type=str, multiple=True)
 @click.option('--outdir', help='The output directory to create and write dbGaP files to.', type=click.Path(file_okay=False, dir_okay=True, exists=False), default='data/ncpi-dataset-catalog')
 def get_dbgap_data_dicts(input_file, format, field, outdir):
@@ -61,12 +61,14 @@ def get_dbgap_data_dicts(input_file, format, field, outdir):
     Given a TSV or CSV file with a `dbgap_study_id` field, download all dbGaP variables for Dug ingest.
 
     SYNOPSIS
-        python get_dbgap_data_dicts.py [input_file]
+
+    python get_dbgap_data_dicts.py [input_file]
 
     Where input_file is the TSV file to read data from. (To use a CSV file instead, add `--format csv`).
 
     EXAMPLE
-        python get_dbgap_data_dicts.py data/ncpi-dataset-catalog-results.tsv --format tsv --field "Study Accession" --outdir
+    
+    python get_dbgap_data_dicts.py data/ncpi-dataset-catalog-results.tsv --format tsv --field "Study Accession" --outdir
 
     :param input_file: The input file containing dbGaP identifiers.
     :param format: The format of the input file.

--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -4,59 +4,81 @@ get_dbgap_data_dicts.py - Download data dictionaries from dbGaP in a format that
 Based on get_ncpi_data_dicts.py.
 """
 
+import logging
 import os
 import shutil
 from ftplib import FTP, error_perm
 import csv
 import click
 
-# Hard-coded relative paths for the anvil catalog input file and output bolus
-# This obviously isn't very elegant but it'll do for now
-input_file = "../data/ncpi-dataset-catalog-results.tsv"
-output_dir = "../data/"
-
+# Default to logging at the INFO level.
+logging.basicConfig(level=logging.DEBUG)
 
 # Helper function
-def download_dbgap_study(study_id, output_dir):
-    # Download a dbgap study to a specific directory
+def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
+    """
+    Download a dbGaP study to a specific directory.
+
+    :param dbgap_accession_id: The dbGaP study identifier to use. This should include the version number, e.g. `phs002206.v2.p1`.
+    :param dbgap_output_dir: The directory to download files to.
+    :return: The number of downloaded variables.
+    """
+
+    count_downloaded_vars = 0
 
     ftp = FTP('ftp.ncbi.nlm.nih.gov')
     ftp.login()
-    study_variable = study_id.split('.')[0]
-    os.makedirs(f"{output_dir}/{study_id}")
+    study_variable = dbgap_accession_id.split('.')[0]
+
+    # The output directory already includes the study accession number.
+    local_path = dbgap_output_dir # os.path.join(dbgap_output_dir, dbgap_accession_id)
+    os.makedirs(local_path, exist_ok=True)
+
+    study_id_path = f"/dbgap/studies/{study_variable}/{dbgap_accession_id}"
 
     # Step 1: First we try and get all the data_dict files
     try:
-        ftp.cwd(f"/dbgap/studies/{study_variable}/{study_id}/pheno_variable_summaries")
+        ftp.cwd(f"{study_id_path}/pheno_variable_summaries")
     except error_perm:
-        print(f"WARN: Unable to find data dicts for study: {study_id}")
         # Delete subdirectory so we don't think it's full
-        shutil.rmtree(f"{output_dir}/{study_id}")
-        return False
+        shutil.rmtree(local_path)
+        try:
+            files_in_dir = ftp.nlst(study_id_path)
+        except:
+            logging.error(f"dbGaP study accession identifier not found in dbGaP data: {dbgap_accession_id}")
+            return 0
+
+        logging.warning(f"No data dictionaries available for study {dbgap_accession_id}: {files_in_dir}")
+        return 0
 
     ftp_filelist = ftp.nlst(".")
     for ftp_filename in ftp_filelist:
         if 'data_dict' in ftp_filename:
-            with open(f"{output_dir}/{study_id}/{ftp_filename}", "wb") as data_dict_file:
-                    ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
+            with open(f"{local_path}/{ftp_filename}", "wb") as data_dict_file:
+                ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
+                logging.debug(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
+            count_downloaded_vars += 1
 
     # Step 2: Check to see if there's a GapExchange file in the parent folder
     #         and if there is, get it.
-    ftp.cwd(f"/dbgap/studies/{study_variable}/{study_id}")
+    ftp.cwd(study_id_path)
     ftp_filelist = ftp.nlst(".")
     for ftp_filename in ftp_filelist:
         if 'GapExchange' in ftp_filename:
-            with open(f"{output_dir}/{study_id}/{ftp_filename}", "wb") as data_dict_file:
+            with open(f"{local_path}/{ftp_filename}", "wb") as data_dict_file:
                 ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
+                logging.debug(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
     ftp.quit()
-    return True
+    return count_downloaded_vars
 
 @click.command()
-@click.argument('input_file')
-@click.option('--format', help='The format of the input file.', type=click.Choice(['CSV', 'TSV']), default='tsv')
+@click.argument('input_file', type=click.File('r'))
+@click.option('--format', help='The format of the input file.', type=click.Choice(['CSV', 'TSV']), default='TSV')
 @click.option('--field', help='The field name containing dbGaP study IDs or accession IDs.', default='dbgap_study_accession', type=str, multiple=True)
-@click.option('--outdir', help='The output directory to create and write dbGaP files to.', type=click.Path(file_okay=False, dir_okay=True, exists=False), default='data/ncpi-dataset-catalog')
-def get_dbgap_data_dicts(input_file, format, field, outdir):
+@click.option('--outdir', help='The output directory to create and write dbGaP files to.', type=click.Path(file_okay=False, dir_okay=True, exists=False), default='data/dbgap')
+@click.option('--group-by', help='Create subdirectories for the specified fields.', type=str, multiple=True)
+@click.option('--skip', help='dbGaP identifier to skip when downloading.', type=str, multiple=True)
+def get_dbgap_data_dicts(input_file, format, field, outdir, group_by, skip):
     """
     Given a TSV or CSV file with a `dbgap_study_id` field, download all dbGaP variables for Dug ingest.
 
@@ -67,75 +89,78 @@ def get_dbgap_data_dicts(input_file, format, field, outdir):
     Where input_file is the TSV file to read data from. (To use a CSV file instead, add `--format csv`).
 
     EXAMPLE
-    
+
     python get_dbgap_data_dicts.py data/ncpi-dataset-catalog-results.tsv --format tsv --field "Study Accession" --outdir
 
     :param input_file: The input file containing dbGaP identifiers.
     :param format: The format of the input file.
     :param field: A list of field names to look for dbGaP identifiers in.
     :param outdir: The output directory to use. This must not exist when this code is called.
+    :param group_by: Group the outputs into subdirectories based on the specified fields.
     :return: Exit code (0 on success, something else on errors)
     """
+    output_dir = click.format_filename(outdir)
+    dbgap_ids_to_skip = set(skip)
+
+    # `field` is given to us as a tuple. For easier processing, we cast it into a list().
+    fields = list(field)
 
     # Make new output dir
     os.makedirs(f"{output_dir}/", exist_ok=True)
 
-    # Parse input table and download all valid dbgap datasets to output
-    missing_data_dict_studies = {}
-    studies = {}
+    # We support two dialects:
+    #   - "excel": CSV (https://docs.python.org/3/library/csv.html#csv.excel)
+    #   - "excel_tab": TSV (https://docs.python.org/3/library/csv.html#csv.excel_tab)
+    if format == 'CSV':
+        dialect = 'excel'
+    elif format == 'TSV':
+        dialect = 'excel-tab'
+    else:
+        raise RuntimeError(f"Unknown --format specified: {format}")
 
-    with open(input_file) as csv_file:
-        csv_reader = csv.DictReader(csv_file, delimiter="\t")
-        header = False
-        for row in csv_reader:
-            if not header:
-                # Check to make sure tsv contains column for Study Accession
-                if "Study Accession" not in row:
-                    # Throw error if expected column is missing
-                    raise IOError("Input file must contain 'Study Accession' column")
-                header = True
+    count_rows = 0
+    count_downloaded = 0
+    reader = csv.DictReader(input_file, dialect=dialect)
+    for (row_index, row) in enumerate(reader):
+        line_num = row_index + 1
+        count_rows += 1
+
+        # We allow the user to specify multiple fields. In this case, we use dbGaP identifiers from every field,
+        # and only produce an error if every row doesn't have at least one identifier.
+        dbgap_ids = set()
+        for fname in fields:
+            if fname in row and row[fname] != '':
+                dbgap_ids.add(row[fname])
+
+        if not dbgap_ids:
+            raise RuntimeError(f"No dbGaP identifiers found in fields {fields} on line {line_num} of input file: {row}")
+
+        # Determine the output directory. If no group-by fields are specified, just use output_dir.
+        # If multiple group-by fields are specified, we use them in order.
+        output_dir_for_row = output_dir
+        for group_name in list(group_by):
+            if group_name in row:
+                output_dir_for_row = os.path.join(output_dir_for_row, row[group_name])
+            else:
+                output_dir_for_row = os.path.join(output_dir_for_row, '__missing__')
+
+        logging.debug(f"Row {line_num} containing dbGaP IDs {dbgap_ids} will be written to {output_dir_for_row}")
+        os.makedirs(output_dir_for_row, exist_ok=True)
+
+        for dbgap_id in sorted(list(dbgap_ids)):
+            # TODO: this skip logic was added to deal with phs000285.v3.p2 and phs000007.v32.p13, which doesn't work
+            # for some reason.
+            if dbgap_id in dbgap_ids_to_skip:
+                logging.info(f"Skipping dbGaP ID {dbgap_id}")
                 continue
 
-            # Get platform and make subdir if necessary
-            platform = row["Platform"].split(";")
-            platform = platform[0] if "BDC" not in platform else "BDC"
+            dbgap_dir = os.path.join(output_dir_for_row, dbgap_id)
+            # Try to download to output folder if the study hasn't already been downloaded
+            if not os.path.exists(dbgap_dir):
+                logging.info(f"Downloading {dbgap_id} to {dbgap_dir}")
+                count_downloaded += download_dbgap_study(dbgap_id, dbgap_dir)
 
-            # Add any phs dbgap studies to queue of files to get
-            study_id = row["Study Accession"]
-            if study_id.startswith("phs") and study_id not in studies:
-                studies[study_id] = True
-                try:
-                    # Try to download to output folder if the study hasn't already been downloaded
-                    if not os.path.exists(f"{output_dir}/{platform}/{study_id}"):
-                        print(f"Downloading: {study_id}")
-                        if not download_dbgap_study(study_id, f"{output_dir}/{platform}"):
-                            missing_data_dict_studies[study_id] = True
-
-                except Exception as e:
-                    # If anything happens, delete the folder so we don't mistake it for success
-                    shutil.rmtree(f"{output_dir}/{platform}/{study_id}")
-
-    # Count the number subdir currently in output_dir as the number of downloaded
-    num_downloaded  = len([path for path in os.walk(output_dir) if path[0] != output_dir])
-
-    # Get number of failed for missing data dicts
-    num_missing_data_dicts = len(list(missing_data_dict_studies.keys()))
-
-    # Total number of possible unique studies
-    num_possible = len(list(studies.keys()))
-
-    # Write out list of datasets with no data dicts
-    with open(f"{output_dir}/download_summary.txt", "w") as sum_file:
-        sum_file.write(f"Unique dbgap datasets in ncpi table: {num_possible}\n")
-        sum_file.write(f"Successfully Downloaded: {num_downloaded}\n")
-        sum_file.write(f"Total dbgap datasests missing data dicts: {num_missing_data_dicts}\n")
-        sum_file.write(f"Dbgap datasests missing data dicts:\n")
-        for item in missing_data_dict_studies:
-            sum_file.write(f"{item}\n")
-
-    print(f"Unique dbgap datasets in ncpi table: {num_possible}\n")
-    print(f"Successfully Downloaded: {num_downloaded}\n")
-    print(f"Total dbgap datasests missing data dicts: {num_missing_data_dicts}\n")
+    logging.info(f"Downloaded {count_downloaded} studies from {count_rows} in input files.")
 
 
 if __name__ == "__main__":

--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -1,0 +1,140 @@
+"""
+get_dbgap_data_dicts.py - Download data dictionaries from dbGaP in a format that Dug can ingest.
+
+Based on get_ncpi_data_dicts.py.
+"""
+
+import os
+import shutil
+from ftplib import FTP, error_perm
+import csv
+import click
+
+# Hard-coded relative paths for the anvil catalog input file and output bolus
+# This obviously isn't very elegant but it'll do for now
+input_file = "../data/ncpi-dataset-catalog-results.tsv"
+output_dir = "../data/"
+
+
+# Helper function
+def download_dbgap_study(study_id, output_dir):
+    # Download a dbgap study to a specific directory
+
+    ftp = FTP('ftp.ncbi.nlm.nih.gov')
+    ftp.login()
+    study_variable = study_id.split('.')[0]
+    os.makedirs(f"{output_dir}/{study_id}")
+
+    # Step 1: First we try and get all the data_dict files
+    try:
+        ftp.cwd(f"/dbgap/studies/{study_variable}/{study_id}/pheno_variable_summaries")
+    except error_perm:
+        print(f"WARN: Unable to find data dicts for study: {study_id}")
+        # Delete subdirectory so we don't think it's full
+        shutil.rmtree(f"{output_dir}/{study_id}")
+        return False
+
+    ftp_filelist = ftp.nlst(".")
+    for ftp_filename in ftp_filelist:
+        if 'data_dict' in ftp_filename:
+            with open(f"{output_dir}/{study_id}/{ftp_filename}", "wb") as data_dict_file:
+                    ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
+
+    # Step 2: Check to see if there's a GapExchange file in the parent folder
+    #         and if there is, get it.
+    ftp.cwd(f"/dbgap/studies/{study_variable}/{study_id}")
+    ftp_filelist = ftp.nlst(".")
+    for ftp_filename in ftp_filelist:
+        if 'GapExchange' in ftp_filename:
+            with open(f"{output_dir}/{study_id}/{ftp_filename}", "wb") as data_dict_file:
+                ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
+    ftp.quit()
+    return True
+
+@click.command()
+@click.argument('input_file')
+@click.option('--format', help='The format of the input file.', type=click.Choice(['CSV', 'TSV']), default='tsv', case_sensitive=False)
+@click.option('--field', help='The field name containing dbGaP study IDs or accession IDs.', default='dbgap_study_accession', type=str, multiple=True)
+@click.option('--outdir', help='The output directory to create and write dbGaP files to.', type=click.Path(file_okay=False, dir_okay=True, exists=False), default='data/ncpi-dataset-catalog')
+def get_dbgap_data_dicts(input_file, format, field, outdir):
+    """
+    Given a TSV or CSV file with a `dbgap_study_id` field, download all dbGaP variables for Dug ingest.
+
+    SYNOPSIS
+        python get_dbgap_data_dicts.py [input_file]
+
+    Where input_file is the TSV file to read data from. (To use a CSV file instead, add `--format csv`).
+
+    EXAMPLE
+        python get_dbgap_data_dicts.py data/ncpi-dataset-catalog-results.tsv --format tsv --field "Study Accession" --outdir
+
+    :param input_file: The input file containing dbGaP identifiers.
+    :param format: The format of the input file.
+    :param field: A list of field names to look for dbGaP identifiers in.
+    :param outdir: The output directory to use. This must not exist when this code is called.
+    :return: Exit code (0 on success, something else on errors)
+    """
+
+    # Make new output dir
+    os.makedirs(f"{output_dir}/", exist_ok=True)
+
+    # Parse input table and download all valid dbgap datasets to output
+    missing_data_dict_studies = {}
+    studies = {}
+
+    with open(input_file) as csv_file:
+        csv_reader = csv.DictReader(csv_file, delimiter="\t")
+        header = False
+        for row in csv_reader:
+            if not header:
+                # Check to make sure tsv contains column for Study Accession
+                if "Study Accession" not in row:
+                    # Throw error if expected column is missing
+                    raise IOError("Input file must contain 'Study Accession' column")
+                header = True
+                continue
+
+            # Get platform and make subdir if necessary
+            platform = row["Platform"].split(";")
+            platform = platform[0] if "BDC" not in platform else "BDC"
+
+            # Add any phs dbgap studies to queue of files to get
+            study_id = row["Study Accession"]
+            if study_id.startswith("phs") and study_id not in studies:
+                studies[study_id] = True
+                try:
+                    # Try to download to output folder if the study hasn't already been downloaded
+                    if not os.path.exists(f"{output_dir}/{platform}/{study_id}"):
+                        print(f"Downloading: {study_id}")
+                        if not download_dbgap_study(study_id, f"{output_dir}/{platform}"):
+                            missing_data_dict_studies[study_id] = True
+
+                except Exception as e:
+                    # If anything happens, delete the folder so we don't mistake it for success
+                    shutil.rmtree(f"{output_dir}/{platform}/{study_id}")
+
+    # Count the number subdir currently in output_dir as the number of downloaded
+    num_downloaded  = len([path for path in os.walk(output_dir) if path[0] != output_dir])
+
+    # Get number of failed for missing data dicts
+    num_missing_data_dicts = len(list(missing_data_dict_studies.keys()))
+
+    # Total number of possible unique studies
+    num_possible = len(list(studies.keys()))
+
+    # Write out list of datasets with no data dicts
+    with open(f"{output_dir}/download_summary.txt", "w") as sum_file:
+        sum_file.write(f"Unique dbgap datasets in ncpi table: {num_possible}\n")
+        sum_file.write(f"Successfully Downloaded: {num_downloaded}\n")
+        sum_file.write(f"Total dbgap datasests missing data dicts: {num_missing_data_dicts}\n")
+        sum_file.write(f"Dbgap datasests missing data dicts:\n")
+        for item in missing_data_dict_studies:
+            sum_file.write(f"{item}\n")
+
+    print(f"Unique dbgap datasets in ncpi table: {num_possible}\n")
+    print(f"Successfully Downloaded: {num_downloaded}\n")
+    print(f"Total dbgap datasests missing data dicts: {num_missing_data_dicts}\n")
+
+
+if __name__ == "__main__":
+    get_dbgap_data_dicts()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ redis==4.4.2
 requests==2.28.2
 requests-cache==0.9.8
 six==1.16.0
+
+# Click for command line arguments
+# We use Click 7.0 because that's what one of the pinned packages above use.
+click~=7.0


### PR DESCRIPTION
This PR adds a script, `bin/get_dbgap_data_dicts.py`, which can be used to download all the dbGaP identifiers from a CSV or TSV file into a specified directory. It is based on `bin/get_ncpi_data_dicts.py`, but is much more configurable.

There is an unknown bug which you can replicate by trying to download [`phs000285.v3.p2`](https://ftp.ncbi.nlm.nih.gov/dbgap/studies/phs000285/phs000285.v3.p2/) or [`phs000007.v32.p13`](https://ftp.ncbi.nlm.nih.gov/dbgap/studies/phs000007/phs000007.v32.p13/). Since we need this functionality for BDC ingest, I'm inclined to merge this PR and open an issue for that bug to be debugged later, but I'm happy to try to fix it in this PR first if that is preferable.

You can test this by running:

```shell
$ python bin/get_dbgap_data_dicts.py data/ncpi-dataset-catalog-results.tsv --field "Study Accession" --group-by Platform --outdir data/ncpi-dataset-catalog --skip phs000285.v3.p2 --skip phs000007.v32.p1
```