### PR TITLE
Add BDC dbGaP IDs

### DIFF
--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -13,7 +13,7 @@ import click
 import socket
 
 # Default to logging at the INFO level.
-# logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 # Helper function
 def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
@@ -67,7 +67,7 @@ def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
                     logging.error(f"Socket error, skipping file {ftp_filename}:", e)
                     continue
 
-                logging.debug(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
+                logging.info(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
             count_downloaded_vars += 1
 
     # Step 2: Check to see if there's a GapExchange file in the parent folder
@@ -78,7 +78,7 @@ def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
         if 'GapExchange' in ftp_filename:
             with open(f"{local_path}/{ftp_filename}", "wb") as data_dict_file:
                 ftp.retrbinary(f"RETR {ftp_filename}", data_dict_file.write)
-                logging.debug(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
+                logging.info(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
     ftp.quit()
     return count_downloaded_vars
 

--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -13,7 +13,7 @@ import click
 import socket
 
 # Default to logging at the INFO level.
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 # Helper function
 def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
@@ -40,13 +40,14 @@ def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
     # Step 1: First we try and get all the data_dict files
     try:
         ftp.cwd(f"{study_id_path}/pheno_variable_summaries")
-    except error_perm:
+    except error_perm as e1:
+        logging.warning(f"Exception {e1} thrown when trying to access {study_id_path}/pheno_variable_summaries on the dbGaP FTP server.")
         # Delete subdirectory so we don't think it's full
         shutil.rmtree(local_path)
         try:
             files_in_dir = ftp.nlst(study_id_path)
-        except:
-            logging.error(f"dbGaP study accession identifier not found on dbGaP server: {study_id_path}")
+        except error_perm as e2:
+            logging.error(f"dbGaP study accession identifier not found on dbGaP server ({e2}): {study_id_path}")
             return 0
 
         logging.warning(f"No data dictionaries available for study {dbgap_accession_id}: {files_in_dir}")

--- a/bin/get_dbgap_data_dicts.py
+++ b/bin/get_dbgap_data_dicts.py
@@ -62,14 +62,14 @@ def download_dbgap_study(dbgap_accession_id, dbgap_output_dir):
 
                 # ftp.retrbinary() seems to cause this program to crash.
                 # Luckily, dbGaP is also available on HTTP!
-                filename_url = urljoin("https://ftp.ncbi.nlm.nih.gov/", ftp_filename)
+                filename_url = f"https://ftp.ncbi.nlm.nih.gov/{study_id_path}/pheno_variable_summaries/{ftp_filename}"
                 response = requests.get(filename_url)
                 if not response.ok:
                     logging.error(f"Could not download {filename_url}: {response}")
                     continue
 
                 data_dict_file.write(response.content)
-                logging.info(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename}")
+                logging.info(f"Downloaded {ftp_filename} to {local_path}/{ftp_filename} in {response.elapsed.microseconds} microseconds.")
             count_downloaded_vars += 1
 
     # Step 2: Check to see if there's a GapExchange file in the parent folder
@@ -164,7 +164,7 @@ def get_dbgap_data_dicts(input_file, format, field, outdir, group_by, skip):
             # TODO: this skip logic was added to deal with phs000285.v3.p2 and phs000007.v32.p13, which doesn't work
             # for some reason.
             if dbgap_id in dbgap_ids_to_skip:
-                logging.info(f"Skipping dbGaP ID {dbgap_id}")
+                logging.info(f"Skipping dbGaP accession {dbgap_id}")
                 continue
 
             dbgap_dir = os.path.join(output_dir_for_row, dbgap_id)

--- a/data/bdc_dbgap_download.sh
+++ b/data/bdc_dbgap_download.sh
@@ -9,4 +9,4 @@ OUTPUT_DIR=bdc_dbgap_data_dicts
 SCRIPT=../bin/get_dbgap_data_dicts.py
 
 mkdir -p $OUTPUT_DIR
-python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR
+python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR 2> $OUTPUT_DIR/errors.txt

--- a/data/bdc_dbgap_download.sh
+++ b/data/bdc_dbgap_download.sh
@@ -9,4 +9,4 @@ OUTPUT_DIR=bdc_dbgap_data_dicts
 SCRIPT=../bin/get_dbgap_data_dicts.py
 
 mkdir -p $OUTPUT_DIR
-python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR 2> $OUTPUT_DIR/errors.txt
+python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR

--- a/data/bdc_dbgap_download.sh
+++ b/data/bdc_dbgap_download.sh
@@ -9,4 +9,4 @@ OUTPUT_DIR=bdc_dbgap_data_dicts
 SCRIPT=../bin/get_dbgap_data_dicts.py
 
 mkdir -p $OUTPUT_DIR
-python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR
+python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR --skip phs000571.v6.p2

--- a/data/bdc_dbgap_download.sh
+++ b/data/bdc_dbgap_download.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Download the data dictionaries from dbGaP as listed in bdc_dbgap_ids.csv
+# into the bdc_dbgap/ directory.
+#
+
+CSV_FILE=bdc_dbgap_ids.csv
+OUTPUT_DIR=bdc_dbgap_data_dicts
+SCRIPT=../bin/get_dbgap_data_dicts.py
+
+mkdir -p $OUTPUT_DIR
+python $SCRIPT $CSV_FILE --format CSV --field Accession --outdir $OUTPUT_DIR

--- a/data/bdc_dbgap_ids.csv
+++ b/data/bdc_dbgap_ids.csv
@@ -1,154 +1,154 @@
-Accession,Consent,Study Name,Last modified
-phs000007.v31.p12,c1,Framingham Cohort,2023-03-27
-phs000007.v31.p12,c2,Framingham Cohort,2023-03-27
-phs000166.v2.p1,c1,"National Heart, Lung, and Blood Institute SNP Health Association Asthma Resource Project (SHARP)",2023-03-27
-phs000179.v6.p2,c1,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27
-phs000179.v6.p2,c2,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27
-phs000200.v12.p3,c1,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27
-phs000200.v12.p3,c2,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27
-phs000209.v13.p3,c1,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27
-phs000209.v13.p3,c2,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27
-phs000284.v2.p1,c1,NHLBI Cleveland Family Study (CFS) Candidate Gene Association Resource (CARe),2023-03-27
-phs000285.v3.p2,c1,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27
-phs000285.v3.p2,c2,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27
-phs000286.v6.p2,c1,Jackson Heart Study (JHS) Cohort,2023-03-27
-phs000286.v6.p2,c2,Jackson Heart Study (JHS) Cohort,2023-03-27
-phs000286.v6.p2,c3,Jackson Heart Study (JHS) Cohort,2023-03-27
-phs000286.v6.p2,c4,Jackson Heart Study (JHS) Cohort,2023-03-27
-phs000287.v7.p1,c1,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
-phs000287.v7.p1,c2,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
-phs000287.v7.p1,c3,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
-phs000287.v7.p1,c4,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
-phs000289.v2.p1,c1,National Human Genome Research Institute (NHGRI) GENEVA Genome-Wide Association Study of Venous Thrombosis (GWAS of VTE),2023-03-27
-phs000422.v1.p1,c1,NHLBI GO-ESP: Lung Cohorts Exome Sequencing Project (Asthma): Genetic variants affecting susceptibility and severity,2023-03-27
-phs000571.v6.p2,c1,Congenital Heart Disease Genetic Network Study,2023-03-27
-phs000703.v1.p1,c1,CATHeterization GENetics (CATHGEN),2023-03-27
-phs000784.v3.p1,c1,Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27
-phs000810.v1.p1,c1,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27
-phs000810.v1.p1,c2,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27
-phs000820.v1.p1,c1,The Cleveland Clinic Foundation's Lone Atrial Fibrillation GWAS Study,2023-03-27
-phs000914.v1.p1,c1,Genome-Wide Association Study of Adiposity in Samoans,2023-03-27
-phs000920.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Genes-Environments and Admixture in Latino Asthmatics (GALA II),2023-03-27
-phs000921.v4.p1,c2,"NHLBI TOPMed: Study of African Americans, Asthma, Genes and Environment (SAGE)",2023-03-27
-phs000946.v4.p1,c1,NHLBI TOPMed: Boston Early-Onset COPD Study,2023-03-27
-phs000951.v4.p4,c1,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27
-phs000951.v4.p4,c2,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27
-phs000954.v3.p2,c1,NHLBI TOPMed: The Cleveland Family Study (CFS),2023-03-27
-phs000956.v4.p1,c2,NHLBI TOPMed: Genetics of Cardiometabolic Health in the Amish,2023-03-27
-phs000964.v4.p1,c1,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
-phs000964.v4.p1,c2,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
-phs000964.v4.p1,c3,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
-phs000964.v4.p1,c4,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
-phs000972.v4.p1,c1,NHLBI TOPMed: Genome-Wide Association Study of Adiposity in Samoans,2023-03-27
-phs000974.v4.p3,c1,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27
-phs000974.v4.p3,c2,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27
-phs000988.v4.p1,c1,NHLBI TOPMed: The Genetic Epidemiology of Asthma in Costa Rica,2023-03-27
-phs000993.v4.p2,c1,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27
-phs000993.v4.p2,c2,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27
-phs000997.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt AF Ablation Registry,2023-03-27
-phs001001.v1.p1,c1,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
-phs001001.v1.p1,c2,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
-phs001012.v1.p1,c1,The Diabetes Heart Study (DHS),2023-03-27
-phs001013.v3.p2,c1,Heart and Vascular Health Study (HVH),2023-03-27
-phs001013.v3.p2,c2,Heart and Vascular Health Study (HVH),2023-03-27
-phs001024.v4.p1,c1,NHLBI TOPMed: Partners HealthCare Biobank,2023-03-27
-phs001032.v5.p2,c1,NHLBI TOPMed: The Vanderbilt Atrial Fibrillation Registry (VU_AF),2023-03-27
-phs001040.v4.p1,c1,NHLBI TOPMed: Novel Risk Factors for the Development of Atrial Fibrillation in Women,2023-03-27
-phs001062.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
-phs001062.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
-phs001074.v1.p1,c2,GeneSTAR (Genetic Study of Atherosclerosis Risk) NextGen Consortium: Functional Genomics of Platelet Aggregation Using iPS and Derived Megakaryocytes,2023-03-27
-phs001143.v3.p1,c1,NHLBI TOPMed: The Genetics and Epidemiology of Asthma in Barbados,2023-03-27
-phs001180.v2.p1,c2,Genes-Environments and Admixture in Latino Asthmatics (GALA II) Study,2023-03-27
-phs001189.v3.p1,c1,NHLBI TOPMed: Cleveland Clinic Atrial Fibrillation (CCAF) Study,2023-03-27
-phs001194.v2.p2,c1,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27
-phs001194.v2.p2,c2,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27
-phs001207.v2.p1,c1,NHLBI TOPMed: African American Sarcoidosis Genetics Resource,2023-03-27
-phs001211.v3.p2,c1,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27
-phs001211.v3.p2,c2,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27
-phs001215.v3.p2,c1,NHLBI TOPMed: San Antonio Family Heart Study (SAFHS),2023-03-27
-phs001217.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27
-phs001218.v2.p1,c2,NHLBI TOPMed: Genetic Study of Atherosclerosis Risk (GeneSTAR),2023-03-27
-phs001237.v2.p1,c1,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27
-phs001237.v2.p1,c2,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27
-phs001238.v2.p1,c1,Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27
-phs001252.v1.p1,c1,Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27
-phs001293.v2.p1,c1,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27
-phs001293.v2.p1,c2,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27
-phs001345.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27
-phs001359.v2.p1,c1,NHLBI TOPMed: GOLDN Epigenetic Determinants of Lipid Response to Dietary Fat and Fenofibrate,2023-03-27
-phs001368.v2.p2,c1,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
-phs001368.v2.p2,c2,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
-phs001368.v2.p2,c4,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
-phs001387.v2.p1,c3,NHLBI TOPMed: Rare Variants for Hypertension in Taiwan Chinese (THRV),2023-03-27
-phs001395.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27
-phs001395.v1.p1,c2,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27
-phs001402.v2.p1,c1,NHLBI TOPMed: Whole Genome Sequencing of Venous Thromboembolism (WGS of VTE),2023-03-27
-phs001412.v2.p1,c1,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27
-phs001412.v2.p1,c2,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27
-phs001416.v2.p1,c1,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27
-phs001416.v2.p1,c2,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27
-phs001434.v1.p1,c1,NHLBI TOPMed: Defining the time-dependent genetic and transcriptomic responses to cardiac injury among patients with arrhythmias,2023-03-27
-phs001435.v1.p1,c1,NHLBI TOPMed: Australian Familial Atrial Fibrillation Study,2023-03-27
-phs001466.v1.p1,c1,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
-phs001466.v1.p1,c2,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
-phs001466.v1.p1,c3,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
-phs001467.v1.p1,c1,NHLBI TOPMed: Study of Asthma Phenotypes and Pharmacogenomic Interactions by Race-Ethnicity (SAPPHIRE),2023-03-27
-phs001468.v2.p1,c1,NHLBI TOPMed: REDS-III Brazil Sickle Cell Disease Cohort (REDS-BSCDC),2023-03-27
-phs001472.v1.p1,c1,NHLBI TOPMed: Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27
-phs001514.v1.p1,c1,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27
-phs001514.v1.p1,c2,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27
-phs001515.v1.p1,c1,NHLBI TOPMed: MyLifeOurFuture (MLOF) Research Repository of patients with hemophilia A (factor VIII deficiency) or hemophilia B (factor IX deficiency),2023-03-27
-phs001542.v1.p1,c2,NHLBI TOPMed: Genetics of Asthma in Latino Americans (GALA),2023-03-27
-phs001543.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: AF Biobank LMU in the context of the MED Biobank LMU,2023-03-27
-phs001544.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Malmo Preventive Project (MPP),2023-03-27
-phs001545.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Intermountain INSPIRE Registry,2023-03-27
-phs001546.v1.p1,c1,NHLBI TOPMed: Determining the association of chromosomal variants with non-PV triggers and ablation-outcome in AF (DECAF),2023-03-27
-phs001547.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The GENetics in Atrial Fibrillation (GENAF) Study,2023-03-27
-phs001598.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Johns Hopkins University School of Medicine Atrial Fibrillation Genetics Study,2023-03-27
-phs001599.v1.p1,c1,NHLBI TOPMed: Boston-Brazil Sickle Cell Disease (SCD) Cohort,2023-03-27
-phs001600.v2.p2,c1,NHLBI TOPMed - NHGRI CCDG: Early-onset Atrial Fibrillation in the CATHeterization GENetics (CATHGEN) Cohort,2023-03-27
-phs001601.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Penn Medicine BioBank Early Onset Atrial Fibrillation Study,2023-03-27
-phs001602.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genetic Approaches to Gene-Air Pollution Interactions in Asthma (GAP),2023-03-27
-phs001603.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genomics and Environmental Research of Asthma (IGERA),2023-03-27
-phs001604.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Effects of Air Pollution on the Development of Obesity in Children (Meta-AIR),2023-03-27
-phs001605.v1.p1,c2,NHLBI TOPMed: Chicago Initiative to Raise Asthma Health Equity (CHIRAH),2023-03-27
-phs001606.v1.p1,c1,NHLBI TOPMed: Early-onset Atrial Fibrillation in the Estonian Biobank,2023-03-27
-phs001607.v2.p2,c1,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
-phs001607.v2.p2,c2,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
-phs001607.v2.p2,c3,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
-phs001607.v2.p2,c4,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
-phs001607.v2.p2,c5,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
-phs001608.v1.p1,c1,NHLBI TOPMed: Outcome Modifying Genes in Sickle Cell Disease (OMG),2023-03-27
-phs001612.v1.p1,c1,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27
-phs001612.v1.p1,c2,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27
-phs001624.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt University BioVU Atrial Fibrillation Genetics Study,2023-03-27
-phs001644.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The BioMe Biobank at Mount Sinai,2023-03-27
-phs001661.v2.p1,c1,NHLBI TOPMed: Genetic Causes of Complex Pediatric Disorders - Asthma (GCPD-A),2023-03-27
-phs001662.v1.p1,c2,NHLBI TOPMed: Lung Tissue Research Consortium (LTRC),2023-03-27
-phs001682.v1.p1,c1,NHLBI TOPMed: Pulmonary Hypertension and the Hypoxic Response in SCD (PUSH),2023-03-27
-phs001725.v1.p1,c1,NHLBI TOPMed CCDG: Groningen Genetics of Atrial Fibrillation (GGAF) Study,2023-03-27
-phs001726.v1.p1,c1,NHLBI TOPMed: Childhood Asthma Management Program (CAMP),2023-03-27
-phs001727.v1.p1,c2,NHLBI TOPMed: Pathways to Immunologically Mediated Asthma (PIMA),2023-03-27
-phs001728.v1.p1,c2,NHLBI TOPMed: Best ADd-on Therapy Giving Effective Response (BADGER),2023-03-27
-phs001729.v1.p1,c2,NHLBI TOPMed: Characterizing the Response to a Leukotriene Receptor Antagonist and an Inhaled Corticosteroid (CLIC),2023-03-27
-phs001730.v1.p1,c2,NHLBI TOPMed: Pediatric Asthma Controller Trial (PACT),2023-03-27
-phs001732.v1.p1,c2,NHLBI TOPMed: TReating Children to Prevent EXacerbations of Asthma (TREXA),2023-03-27
-phs001735.v2.p1,c1,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27
-phs001735.v2.p1,c2,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27
-phs001843.v1.p2,c1,Pediatric Cardiac Genomics Consortium (PCGC) Study - Centers for Mendelian Genomics Collaboration,2023-03-27
-phs001927.v1.p1,c1,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
-phs001927.v1.p1,c2,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
-phs001927.v1.p1,c3,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
-phs001927.v1.p1,c4,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
-phs002348.v1.p1,c1,Multicenter Study of Hydroxyurea (MSH),2023-03-27
-phs002362.v1.p1,c1,Cooperative Study of Sickle Cell Disease (CSSCD),2023-03-27
-phs002383.v1.p1,c1,Treatment of Pulmonary Hypertension and Sickle Cell Disease With Sildenafil Therapy (walk-PHaSST),2023-03-27
-phs002385.v1.p1,c1,Hematopoietic Cell Transplant for Sickle Cell Disease (HCT for SCD),2023-03-27
-phs002386.v1.p1,c1,Optimizing Primary Stroke Prevention in Children with Sickle Cell Anemia (STOP II),2023-03-27
-phs002415.v1.p1,c1,Hydroxyurea to Prevent Organ Damage in Children with Sickle Cell Anemia (BABY HUG),2023-03-27
-phs002715.v1.p1,c1,Cleveland Family Study,2023-03-27
-phs002299.v1.p1,c1,PETAL Network: Outcomes Related to COVID-19 Treated With Hydroxychloroquine Among Inpatients With Symptomatic Disease (ORCHID) Trial,2023-03-27
-phs002363.v1.p1,c1,PETAL - Repository of Electronic Data COVID-19 Observational Study,2023-03-27
-phs002694.v1.p1,c1,Accelerating COVID-19 Therapeutic Interventions and Vaccines 4 ACUTE (ACTIV-4A),2023-03-27
-phs002710.v1.p1,c1,COVID-19 Positive Outpatient Thrombosis Prevention in Adults Aged 40-80,2023-03-27
-phs002752.v1.p1,c1,Clinical-trial of COVID-19 Convalescent Plasma in Outpatients,2023-03-27
+Accession,Consent,Study Name,Last modified,Notes,
+phs000007.v31.p12,c1,Framingham Cohort,2023-03-27,
+phs000007.v31.p12,c2,Framingham Cohort,2023-03-27,
+phs000166.v2.p1,c1,"National Heart, Lung, and Blood Institute SNP Health Association Asthma Resource Project (SHARP)",2023-03-27,
+phs000179.v6.p2,c1,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27,
+phs000179.v6.p2,c2,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27,
+phs000200.v12.p3,c1,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27,
+phs000200.v12.p3,c2,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27,
+phs000209.v13.p3,c1,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27,
+phs000209.v13.p3,c2,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27,
+phs000284.v2.p1,c1,NHLBI Cleveland Family Study (CFS) Candidate Gene Association Resource (CARe),2023-03-27,
+phs000285.v3.p2,c1,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27,
+phs000285.v3.p2,c2,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27,
+phs000286.v6.p2,c1,Jackson Heart Study (JHS) Cohort,2023-03-27,
+phs000286.v6.p2,c2,Jackson Heart Study (JHS) Cohort,2023-03-27,
+phs000286.v6.p2,c3,Jackson Heart Study (JHS) Cohort,2023-03-27,
+phs000286.v6.p2,c4,Jackson Heart Study (JHS) Cohort,2023-03-27,
+phs000287.v7.p1,c1,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27,
+phs000287.v7.p1,c2,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27,
+phs000287.v7.p1,c3,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27,
+phs000287.v7.p1,c4,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27,
+phs000289.v2.p1,c1,National Human Genome Research Institute (NHGRI) GENEVA Genome-Wide Association Study of Venous Thrombosis (GWAS of VTE),2023-03-27,
+phs000422.v1.p1,c1,NHLBI GO-ESP: Lung Cohorts Exome Sequencing Project (Asthma): Genetic variants affecting susceptibility and severity,2023-03-27,
+phs001194.v3.p2,c1,Congenital Heart Disease Genetic Network Study,2023-03-27,"Listed on BDC as phs000571.v6.p2, but as per https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000571.v6.p2 the data for this study is collected as a substudy of phs001194.v3.p2, so that's where we get the variables for this study."
+phs000703.v1.p1,c1,CATHeterization GENetics (CATHGEN),2023-03-27,
+phs000784.v3.p1,c1,Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27,
+phs000810.v1.p1,c1,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27,
+phs000810.v1.p1,c2,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27,
+phs000820.v1.p1,c1,The Cleveland Clinic Foundation's Lone Atrial Fibrillation GWAS Study,2023-03-27,
+phs000914.v1.p1,c1,Genome-Wide Association Study of Adiposity in Samoans,2023-03-27,
+phs000920.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Genes-Environments and Admixture in Latino Asthmatics (GALA II),2023-03-27,
+phs000921.v4.p1,c2,"NHLBI TOPMed: Study of African Americans, Asthma, Genes and Environment (SAGE)",2023-03-27,
+phs000946.v4.p1,c1,NHLBI TOPMed: Boston Early-Onset COPD Study,2023-03-27,
+phs000951.v4.p4,c1,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27,
+phs000951.v4.p4,c2,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27,
+phs000954.v3.p2,c1,NHLBI TOPMed: The Cleveland Family Study (CFS),2023-03-27,
+phs000956.v4.p1,c2,NHLBI TOPMed: Genetics of Cardiometabolic Health in the Amish,2023-03-27,
+phs000964.v4.p1,c1,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27,
+phs000964.v4.p1,c2,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27,
+phs000964.v4.p1,c3,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27,
+phs000964.v4.p1,c4,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27,
+phs000972.v4.p1,c1,NHLBI TOPMed: Genome-Wide Association Study of Adiposity in Samoans,2023-03-27,
+phs000974.v4.p3,c1,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27,
+phs000974.v4.p3,c2,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27,
+phs000988.v4.p1,c1,NHLBI TOPMed: The Genetic Epidemiology of Asthma in Costa Rica,2023-03-27,
+phs000993.v4.p2,c1,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27,
+phs000993.v4.p2,c2,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27,
+phs000997.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt AF Ablation Registry,2023-03-27,
+phs001001.v1.p1,c1,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27,
+phs001001.v1.p1,c2,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27,
+phs001012.v1.p1,c1,The Diabetes Heart Study (DHS),2023-03-27,
+phs001013.v3.p2,c1,Heart and Vascular Health Study (HVH),2023-03-27,
+phs001013.v3.p2,c2,Heart and Vascular Health Study (HVH),2023-03-27,
+phs001024.v4.p1,c1,NHLBI TOPMed: Partners HealthCare Biobank,2023-03-27,
+phs001032.v5.p2,c1,NHLBI TOPMed: The Vanderbilt Atrial Fibrillation Registry (VU_AF),2023-03-27,
+phs001040.v4.p1,c1,NHLBI TOPMed: Novel Risk Factors for the Development of Atrial Fibrillation in Women,2023-03-27,
+phs001062.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27,
+phs001062.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27,
+phs001074.v1.p1,c2,GeneSTAR (Genetic Study of Atherosclerosis Risk) NextGen Consortium: Functional Genomics of Platelet Aggregation Using iPS and Derived Megakaryocytes,2023-03-27,
+phs001143.v3.p1,c1,NHLBI TOPMed: The Genetics and Epidemiology of Asthma in Barbados,2023-03-27,
+phs001180.v2.p1,c2,Genes-Environments and Admixture in Latino Asthmatics (GALA II) Study,2023-03-27,
+phs001189.v3.p1,c1,NHLBI TOPMed: Cleveland Clinic Atrial Fibrillation (CCAF) Study,2023-03-27,
+phs001194.v2.p2,c1,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27,
+phs001194.v2.p2,c2,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27,
+phs001207.v2.p1,c1,NHLBI TOPMed: African American Sarcoidosis Genetics Resource,2023-03-27,
+phs001211.v3.p2,c1,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27,
+phs001211.v3.p2,c2,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27,
+phs001215.v3.p2,c1,NHLBI TOPMed: San Antonio Family Heart Study (SAFHS),2023-03-27,
+phs001217.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27,
+phs001218.v2.p1,c2,NHLBI TOPMed: Genetic Study of Atherosclerosis Risk (GeneSTAR),2023-03-27,
+phs001237.v2.p1,c1,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27,
+phs001237.v2.p1,c2,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27,
+phs001238.v2.p1,c1,Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27,
+phs001252.v1.p1,c1,Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27,
+phs001293.v2.p1,c1,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27,
+phs001293.v2.p1,c2,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27,
+phs001345.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27,
+phs001359.v2.p1,c1,NHLBI TOPMed: GOLDN Epigenetic Determinants of Lipid Response to Dietary Fat and Fenofibrate,2023-03-27,
+phs001368.v2.p2,c1,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27,
+phs001368.v2.p2,c2,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27,
+phs001368.v2.p2,c4,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27,
+phs001387.v2.p1,c3,NHLBI TOPMed: Rare Variants for Hypertension in Taiwan Chinese (THRV),2023-03-27,
+phs001395.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27,
+phs001395.v1.p1,c2,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27,
+phs001402.v2.p1,c1,NHLBI TOPMed: Whole Genome Sequencing of Venous Thromboembolism (WGS of VTE),2023-03-27,
+phs001412.v2.p1,c1,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27,
+phs001412.v2.p1,c2,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27,
+phs001416.v2.p1,c1,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27,
+phs001416.v2.p1,c2,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27,
+phs001434.v1.p1,c1,NHLBI TOPMed: Defining the time-dependent genetic and transcriptomic responses to cardiac injury among patients with arrhythmias,2023-03-27,
+phs001435.v1.p1,c1,NHLBI TOPMed: Australian Familial Atrial Fibrillation Study,2023-03-27,
+phs001466.v1.p1,c1,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27,
+phs001466.v1.p1,c2,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27,
+phs001466.v1.p1,c3,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27,
+phs001467.v1.p1,c1,NHLBI TOPMed: Study of Asthma Phenotypes and Pharmacogenomic Interactions by Race-Ethnicity (SAPPHIRE),2023-03-27,
+phs001468.v2.p1,c1,NHLBI TOPMed: REDS-III Brazil Sickle Cell Disease Cohort (REDS-BSCDC),2023-03-27,
+phs001472.v1.p1,c1,NHLBI TOPMed: Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27,
+phs001514.v1.p1,c1,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27,
+phs001514.v1.p1,c2,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27,
+phs001515.v1.p1,c1,NHLBI TOPMed: MyLifeOurFuture (MLOF) Research Repository of patients with hemophilia A (factor VIII deficiency) or hemophilia B (factor IX deficiency),2023-03-27,
+phs001542.v1.p1,c2,NHLBI TOPMed: Genetics of Asthma in Latino Americans (GALA),2023-03-27,
+phs001543.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: AF Biobank LMU in the context of the MED Biobank LMU,2023-03-27,
+phs001544.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Malmo Preventive Project (MPP),2023-03-27,
+phs001545.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Intermountain INSPIRE Registry,2023-03-27,
+phs001546.v1.p1,c1,NHLBI TOPMed: Determining the association of chromosomal variants with non-PV triggers and ablation-outcome in AF (DECAF),2023-03-27,
+phs001547.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The GENetics in Atrial Fibrillation (GENAF) Study,2023-03-27,
+phs001598.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Johns Hopkins University School of Medicine Atrial Fibrillation Genetics Study,2023-03-27,
+phs001599.v1.p1,c1,NHLBI TOPMed: Boston-Brazil Sickle Cell Disease (SCD) Cohort,2023-03-27,
+phs001600.v2.p2,c1,NHLBI TOPMed - NHGRI CCDG: Early-onset Atrial Fibrillation in the CATHeterization GENetics (CATHGEN) Cohort,2023-03-27,
+phs001601.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Penn Medicine BioBank Early Onset Atrial Fibrillation Study,2023-03-27,
+phs001602.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genetic Approaches to Gene-Air Pollution Interactions in Asthma (GAP),2023-03-27,
+phs001603.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genomics and Environmental Research of Asthma (IGERA),2023-03-27,
+phs001604.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Effects of Air Pollution on the Development of Obesity in Children (Meta-AIR),2023-03-27,
+phs001605.v1.p1,c2,NHLBI TOPMed: Chicago Initiative to Raise Asthma Health Equity (CHIRAH),2023-03-27,
+phs001606.v1.p1,c1,NHLBI TOPMed: Early-onset Atrial Fibrillation in the Estonian Biobank,2023-03-27,
+phs001607.v2.p2,c1,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27,
+phs001607.v2.p2,c2,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27,
+phs001607.v2.p2,c3,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27,
+phs001607.v2.p2,c4,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27,
+phs001607.v2.p2,c5,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27,
+phs001608.v1.p1,c1,NHLBI TOPMed: Outcome Modifying Genes in Sickle Cell Disease (OMG),2023-03-27,
+phs001612.v1.p1,c1,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27,
+phs001612.v1.p1,c2,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27,
+phs001624.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt University BioVU Atrial Fibrillation Genetics Study,2023-03-27,
+phs001644.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The BioMe Biobank at Mount Sinai,2023-03-27,
+phs001661.v2.p1,c1,NHLBI TOPMed: Genetic Causes of Complex Pediatric Disorders - Asthma (GCPD-A),2023-03-27,
+phs001662.v1.p1,c2,NHLBI TOPMed: Lung Tissue Research Consortium (LTRC),2023-03-27,
+phs001682.v1.p1,c1,NHLBI TOPMed: Pulmonary Hypertension and the Hypoxic Response in SCD (PUSH),2023-03-27,
+phs001725.v1.p1,c1,NHLBI TOPMed CCDG: Groningen Genetics of Atrial Fibrillation (GGAF) Study,2023-03-27,
+phs001726.v1.p1,c1,NHLBI TOPMed: Childhood Asthma Management Program (CAMP),2023-03-27,
+phs001727.v1.p1,c2,NHLBI TOPMed: Pathways to Immunologically Mediated Asthma (PIMA),2023-03-27,
+phs001728.v1.p1,c2,NHLBI TOPMed: Best ADd-on Therapy Giving Effective Response (BADGER),2023-03-27,
+phs001729.v1.p1,c2,NHLBI TOPMed: Characterizing the Response to a Leukotriene Receptor Antagonist and an Inhaled Corticosteroid (CLIC),2023-03-27,
+phs001730.v1.p1,c2,NHLBI TOPMed: Pediatric Asthma Controller Trial (PACT),2023-03-27,
+phs001732.v1.p1,c2,NHLBI TOPMed: TReating Children to Prevent EXacerbations of Asthma (TREXA),2023-03-27,
+phs001735.v2.p1,c1,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27,
+phs001735.v2.p1,c2,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27,
+phs001194.v3.p2,c1,Pediatric Cardiac Genomics Consortium (PCGC) Study - Centers for Mendelian Genomics Collaboration,2023-03-27,"Listed on BDC as phs001843.v1.p2, but as per https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001843.v1.p2 the data for this study is collected as a substudy of phs001194.v3.p2, so that's where we get the variables for this study."
+phs001927.v1.p1,c1,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27,
+phs001927.v1.p1,c2,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27,
+phs001927.v1.p1,c3,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27,
+phs001927.v1.p1,c4,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27,
+phs002348.v1.p1,c1,Multicenter Study of Hydroxyurea (MSH),2023-03-27,
+phs002362.v1.p1,c1,Cooperative Study of Sickle Cell Disease (CSSCD),2023-03-27,
+phs002383.v1.p1,c1,Treatment of Pulmonary Hypertension and Sickle Cell Disease With Sildenafil Therapy (walk-PHaSST),2023-03-27,
+phs002385.v1.p1,c1,Hematopoietic Cell Transplant for Sickle Cell Disease (HCT for SCD),2023-03-27,
+phs002386.v1.p1,c1,Optimizing Primary Stroke Prevention in Children with Sickle Cell Anemia (STOP II),2023-03-27,
+phs002415.v1.p1,c1,Hydroxyurea to Prevent Organ Damage in Children with Sickle Cell Anemia (BABY HUG),2023-03-27,
+phs002715.v1.p1,c1,Cleveland Family Study,2023-03-27,
+phs002299.v1.p1,c1,PETAL Network: Outcomes Related to COVID-19 Treated With Hydroxychloroquine Among Inpatients With Symptomatic Disease (ORCHID) Trial,2023-03-27,
+phs002363.v1.p1,c1,PETAL - Repository of Electronic Data COVID-19 Observational Study,2023-03-27,
+phs002694.v1.p1,c1,Accelerating COVID-19 Therapeutic Interventions and Vaccines 4 ACUTE (ACTIV-4A),2023-03-27,
+phs002710.v1.p1,c1,COVID-19 Positive Outpatient Thrombosis Prevention in Adults Aged 40-80,2023-03-27,
+phs002752.v1.p1,c1,Clinical-trial of COVID-19 Convalescent Plasma in Outpatients,2023-03-27,

--- a/data/bdc_dbgap_ids.csv
+++ b/data/bdc_dbgap_ids.csv
@@ -1,0 +1,154 @@
+Accession,Consent,Study Name,Last modified
+phs000007.v31.p12,c1,Framingham Cohort,2023-03-27
+phs000007.v31.p12,c2,Framingham Cohort,2023-03-27
+phs000166.v2.p1,c1,"National Heart, Lung, and Blood Institute SNP Health Association Asthma Resource Project (SHARP)",2023-03-27
+phs000179.v6.p2,c1,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27
+phs000179.v6.p2,c2,"Genetic Epidemiology of COPD (COPDGene) Funded by the National Heart, Lung, and Blood Institute",2023-03-27
+phs000200.v12.p3,c1,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27
+phs000200.v12.p3,c2,Women's Health Initiative Clinical Trial and Observational Study,2023-03-27
+phs000209.v13.p3,c1,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27
+phs000209.v13.p3,c2,Multi-Ethnic Study of Atherosclerosis (MESA) Cohort,2023-03-27
+phs000284.v2.p1,c1,NHLBI Cleveland Family Study (CFS) Candidate Gene Association Resource (CARe),2023-03-27
+phs000285.v3.p2,c1,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27
+phs000285.v3.p2,c2,Coronary Artery Risk Development in Young Adults (CARDIA) Study - Cohort,2023-03-27
+phs000286.v6.p2,c1,Jackson Heart Study (JHS) Cohort,2023-03-27
+phs000286.v6.p2,c2,Jackson Heart Study (JHS) Cohort,2023-03-27
+phs000286.v6.p2,c3,Jackson Heart Study (JHS) Cohort,2023-03-27
+phs000286.v6.p2,c4,Jackson Heart Study (JHS) Cohort,2023-03-27
+phs000287.v7.p1,c1,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
+phs000287.v7.p1,c2,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
+phs000287.v7.p1,c3,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
+phs000287.v7.p1,c4,Cardiovascular Health Study (CHS) Cohort: an NHLBI-funded observational study of risk factors for cardiovascular disease in adults 65 years or older,2023-03-27
+phs000289.v2.p1,c1,National Human Genome Research Institute (NHGRI) GENEVA Genome-Wide Association Study of Venous Thrombosis (GWAS of VTE),2023-03-27
+phs000422.v1.p1,c1,NHLBI GO-ESP: Lung Cohorts Exome Sequencing Project (Asthma): Genetic variants affecting susceptibility and severity,2023-03-27
+phs000571.v6.p2,c1,Congenital Heart Disease Genetic Network Study,2023-03-27
+phs000703.v1.p1,c1,CATHeterization GENetics (CATHGEN),2023-03-27
+phs000784.v3.p1,c1,Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27
+phs000810.v1.p1,c1,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27
+phs000810.v1.p1,c2,Hispanic Community Health Study /Study of Latinos (HCHS/SOL),2023-03-27
+phs000820.v1.p1,c1,The Cleveland Clinic Foundation's Lone Atrial Fibrillation GWAS Study,2023-03-27
+phs000914.v1.p1,c1,Genome-Wide Association Study of Adiposity in Samoans,2023-03-27
+phs000920.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Genes-Environments and Admixture in Latino Asthmatics (GALA II),2023-03-27
+phs000921.v4.p1,c2,"NHLBI TOPMed: Study of African Americans, Asthma, Genes and Environment (SAGE)",2023-03-27
+phs000946.v4.p1,c1,NHLBI TOPMed: Boston Early-Onset COPD Study,2023-03-27
+phs000951.v4.p4,c1,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27
+phs000951.v4.p4,c2,NHLBI TOPMed: Genetic Epidemiology of COPD (COPDGene),2023-03-27
+phs000954.v3.p2,c1,NHLBI TOPMed: The Cleveland Family Study (CFS),2023-03-27
+phs000956.v4.p1,c2,NHLBI TOPMed: Genetics of Cardiometabolic Health in the Amish,2023-03-27
+phs000964.v4.p1,c1,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
+phs000964.v4.p1,c2,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
+phs000964.v4.p1,c3,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
+phs000964.v4.p1,c4,NHLBI TOPMed: The Jackson Heart Study (JHS),2023-03-27
+phs000972.v4.p1,c1,NHLBI TOPMed: Genome-Wide Association Study of Adiposity in Samoans,2023-03-27
+phs000974.v4.p3,c1,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27
+phs000974.v4.p3,c2,NHLBI TOPMed: Genomic Activities such as Whole Genome Sequencing and Related Phenotypes in the Framingham Heart Study,2023-03-27
+phs000988.v4.p1,c1,NHLBI TOPMed: The Genetic Epidemiology of Asthma in Costa Rica,2023-03-27
+phs000993.v4.p2,c1,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27
+phs000993.v4.p2,c2,NHLBI TOPMed: Heart and Vascular Health Study (HVH),2023-03-27
+phs000997.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt AF Ablation Registry,2023-03-27
+phs001001.v1.p1,c1,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
+phs001001.v1.p1,c2,Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
+phs001012.v1.p1,c1,The Diabetes Heart Study (DHS),2023-03-27
+phs001013.v3.p2,c1,Heart and Vascular Health Study (HVH),2023-03-27
+phs001013.v3.p2,c2,Heart and Vascular Health Study (HVH),2023-03-27
+phs001024.v4.p1,c1,NHLBI TOPMed: Partners HealthCare Biobank,2023-03-27
+phs001032.v5.p2,c1,NHLBI TOPMed: The Vanderbilt Atrial Fibrillation Registry (VU_AF),2023-03-27
+phs001040.v4.p1,c1,NHLBI TOPMed: Novel Risk Factors for the Development of Atrial Fibrillation in Women,2023-03-27
+phs001062.v4.p2,c1,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
+phs001062.v4.p2,c2,NHLBI TOPMed - NHGRI CCDG: Massachusetts General Hospital (MGH) Atrial Fibrillation Study,2023-03-27
+phs001074.v1.p1,c2,GeneSTAR (Genetic Study of Atherosclerosis Risk) NextGen Consortium: Functional Genomics of Platelet Aggregation Using iPS and Derived Megakaryocytes,2023-03-27
+phs001143.v3.p1,c1,NHLBI TOPMed: The Genetics and Epidemiology of Asthma in Barbados,2023-03-27
+phs001180.v2.p1,c2,Genes-Environments and Admixture in Latino Asthmatics (GALA II) Study,2023-03-27
+phs001189.v3.p1,c1,NHLBI TOPMed: Cleveland Clinic Atrial Fibrillation (CCAF) Study,2023-03-27
+phs001194.v2.p2,c1,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27
+phs001194.v2.p2,c2,"National Heart, Lung, and Blood Institute (NHLBI) Bench to Bassinet Program: The Pediatric Cardiac Genetics Consortium (PCGC) Study",2023-03-27
+phs001207.v2.p1,c1,NHLBI TOPMed: African American Sarcoidosis Genetics Resource,2023-03-27
+phs001211.v3.p2,c1,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27
+phs001211.v3.p2,c2,NHLBI TOPMed - NHGRI CCDG: Atherosclerosis Risk in Communities (ARIC),2023-03-27
+phs001215.v3.p2,c1,NHLBI TOPMed: San Antonio Family Heart Study (SAFHS),2023-03-27
+phs001217.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Salt Sensitivity (GenSalt),2023-03-27
+phs001218.v2.p1,c2,NHLBI TOPMed: Genetic Study of Atherosclerosis Risk (GeneSTAR),2023-03-27
+phs001237.v2.p1,c1,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27
+phs001237.v2.p1,c2,NHLBI TOPMed: Women's Health Initiative (WHI),2023-03-27
+phs001238.v2.p1,c1,Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27
+phs001252.v1.p1,c1,Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27
+phs001293.v2.p1,c1,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27
+phs001293.v2.p1,c2,NHLBI TOPMed: HyperGEN - Genetics of Left Ventricular (LV) Hypertrophy,2023-03-27
+phs001345.v2.p1,c1,NHLBI TOPMed: Genetic Epidemiology Network of Arteriopathy (GENOA),2023-03-27
+phs001359.v2.p1,c1,NHLBI TOPMed: GOLDN Epigenetic Determinants of Lipid Response to Dietary Fat and Fenofibrate,2023-03-27
+phs001368.v2.p2,c1,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
+phs001368.v2.p2,c2,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
+phs001368.v2.p2,c4,NHLBI TOPMed: Trans-Omics for Precision Medicine (TOPMed) Whole Genome Sequencing Project: Cardiovascular Health Study,2023-03-27
+phs001387.v2.p1,c3,NHLBI TOPMed: Rare Variants for Hypertension in Taiwan Chinese (THRV),2023-03-27
+phs001395.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27
+phs001395.v1.p1,c2,NHLBI TOPMed - NHGRI CCDG: Hispanic Community Health Study/Study of Latinos (HCHS/SOL),2023-03-27
+phs001402.v2.p1,c1,NHLBI TOPMed: Whole Genome Sequencing of Venous Thromboembolism (WGS of VTE),2023-03-27
+phs001412.v2.p1,c1,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27
+phs001412.v2.p1,c2,NHLBI TOPMed: Diabetes Heart Study (DHS) African American Coronary Artery Calcification (AA CAC),2023-03-27
+phs001416.v2.p1,c1,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27
+phs001416.v2.p1,c2,NHLBI TOPMed: MESA and MESA Family AA-CAC,2023-03-27
+phs001434.v1.p1,c1,NHLBI TOPMed: Defining the time-dependent genetic and transcriptomic responses to cardiac injury among patients with arrhythmias,2023-03-27
+phs001435.v1.p1,c1,NHLBI TOPMed: Australian Familial Atrial Fibrillation Study,2023-03-27
+phs001466.v1.p1,c1,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
+phs001466.v1.p1,c2,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
+phs001466.v1.p1,c3,NHLBI TOPMed: Pharmacogenomics of Hydroxyurea in Sickle Cell Disease (PharmHU),2023-03-27
+phs001467.v1.p1,c1,NHLBI TOPMed: Study of Asthma Phenotypes and Pharmacogenomic Interactions by Race-Ethnicity (SAPPHIRE),2023-03-27
+phs001468.v2.p1,c1,NHLBI TOPMed: REDS-III Brazil Sickle Cell Disease Cohort (REDS-BSCDC),2023-03-27
+phs001472.v1.p1,c1,NHLBI TOPMed: Evaluation of COPD Longitudinally to Identify Predictive Surrogate Endpoints (ECLIPSE),2023-03-27
+phs001514.v1.p1,c1,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27
+phs001514.v1.p1,c2,NHLBI TOPMed: Walk-PHaSST Sickle Cell Disease (SCD),2023-03-27
+phs001515.v1.p1,c1,NHLBI TOPMed: MyLifeOurFuture (MLOF) Research Repository of patients with hemophilia A (factor VIII deficiency) or hemophilia B (factor IX deficiency),2023-03-27
+phs001542.v1.p1,c2,NHLBI TOPMed: Genetics of Asthma in Latino Americans (GALA),2023-03-27
+phs001543.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: AF Biobank LMU in the context of the MED Biobank LMU,2023-03-27
+phs001544.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Malmo Preventive Project (MPP),2023-03-27
+phs001545.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Intermountain INSPIRE Registry,2023-03-27
+phs001546.v1.p1,c1,NHLBI TOPMed: Determining the association of chromosomal variants with non-PV triggers and ablation-outcome in AF (DECAF),2023-03-27
+phs001547.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The GENetics in Atrial Fibrillation (GENAF) Study,2023-03-27
+phs001598.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Johns Hopkins University School of Medicine Atrial Fibrillation Genetics Study,2023-03-27
+phs001599.v1.p1,c1,NHLBI TOPMed: Boston-Brazil Sickle Cell Disease (SCD) Cohort,2023-03-27
+phs001600.v2.p2,c1,NHLBI TOPMed - NHGRI CCDG: Early-onset Atrial Fibrillation in the CATHeterization GENetics (CATHGEN) Cohort,2023-03-27
+phs001601.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: Penn Medicine BioBank Early Onset Atrial Fibrillation Study,2023-03-27
+phs001602.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genetic Approaches to Gene-Air Pollution Interactions in Asthma (GAP),2023-03-27
+phs001603.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Integrative Genomics and Environmental Research of Asthma (IGERA),2023-03-27
+phs001604.v1.p1,c1,NHLBI TOPMed: Children's Health Study (CHS) Effects of Air Pollution on the Development of Obesity in Children (Meta-AIR),2023-03-27
+phs001605.v1.p1,c2,NHLBI TOPMed: Chicago Initiative to Raise Asthma Health Equity (CHIRAH),2023-03-27
+phs001606.v1.p1,c1,NHLBI TOPMed: Early-onset Atrial Fibrillation in the Estonian Biobank,2023-03-27
+phs001607.v2.p2,c1,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
+phs001607.v2.p2,c2,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
+phs001607.v2.p2,c3,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
+phs001607.v2.p2,c4,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
+phs001607.v2.p2,c5,NHLBI TOPMed: Pulmonary Fibrosis Whole Genome Sequencing,2023-03-27
+phs001608.v1.p1,c1,NHLBI TOPMed: Outcome Modifying Genes in Sickle Cell Disease (OMG),2023-03-27
+phs001612.v1.p1,c1,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27
+phs001612.v1.p1,c2,NHLBI TOPMed: Coronary Artery Risk Development in Young Adults (CARDIA),2023-03-27
+phs001624.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The Vanderbilt University BioVU Atrial Fibrillation Genetics Study,2023-03-27
+phs001644.v1.p1,c1,NHLBI TOPMed - NHGRI CCDG: The BioMe Biobank at Mount Sinai,2023-03-27
+phs001661.v2.p1,c1,NHLBI TOPMed: Genetic Causes of Complex Pediatric Disorders - Asthma (GCPD-A),2023-03-27
+phs001662.v1.p1,c2,NHLBI TOPMed: Lung Tissue Research Consortium (LTRC),2023-03-27
+phs001682.v1.p1,c1,NHLBI TOPMed: Pulmonary Hypertension and the Hypoxic Response in SCD (PUSH),2023-03-27
+phs001725.v1.p1,c1,NHLBI TOPMed CCDG: Groningen Genetics of Atrial Fibrillation (GGAF) Study,2023-03-27
+phs001726.v1.p1,c1,NHLBI TOPMed: Childhood Asthma Management Program (CAMP),2023-03-27
+phs001727.v1.p1,c2,NHLBI TOPMed: Pathways to Immunologically Mediated Asthma (PIMA),2023-03-27
+phs001728.v1.p1,c2,NHLBI TOPMed: Best ADd-on Therapy Giving Effective Response (BADGER),2023-03-27
+phs001729.v1.p1,c2,NHLBI TOPMed: Characterizing the Response to a Leukotriene Receptor Antagonist and an Inhaled Corticosteroid (CLIC),2023-03-27
+phs001730.v1.p1,c2,NHLBI TOPMed: Pediatric Asthma Controller Trial (PACT),2023-03-27
+phs001732.v1.p1,c2,NHLBI TOPMed: TReating Children to Prevent EXacerbations of Asthma (TREXA),2023-03-27
+phs001735.v2.p1,c1,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27
+phs001735.v2.p1,c2,NHLBI TOPMed: Pediatric Cardiac Genomics Consortium (PCGC)'s Congenital Heart Disease Biobank,2023-03-27
+phs001843.v1.p2,c1,Pediatric Cardiac Genomics Consortium (PCGC) Study - Centers for Mendelian Genomics Collaboration,2023-03-27
+phs001927.v1.p1,c1,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
+phs001927.v1.p1,c2,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
+phs001927.v1.p1,c3,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
+phs001927.v1.p1,c4,NHLBI TOPMed: SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS),2023-03-27
+phs002348.v1.p1,c1,Multicenter Study of Hydroxyurea (MSH),2023-03-27
+phs002362.v1.p1,c1,Cooperative Study of Sickle Cell Disease (CSSCD),2023-03-27
+phs002383.v1.p1,c1,Treatment of Pulmonary Hypertension and Sickle Cell Disease With Sildenafil Therapy (walk-PHaSST),2023-03-27
+phs002385.v1.p1,c1,Hematopoietic Cell Transplant for Sickle Cell Disease (HCT for SCD),2023-03-27
+phs002386.v1.p1,c1,Optimizing Primary Stroke Prevention in Children with Sickle Cell Anemia (STOP II),2023-03-27
+phs002415.v1.p1,c1,Hydroxyurea to Prevent Organ Damage in Children with Sickle Cell Anemia (BABY HUG),2023-03-27
+phs002715.v1.p1,c1,Cleveland Family Study,2023-03-27
+phs002299.v1.p1,c1,PETAL Network: Outcomes Related to COVID-19 Treated With Hydroxychloroquine Among Inpatients With Symptomatic Disease (ORCHID) Trial,2023-03-27
+phs002363.v1.p1,c1,PETAL - Repository of Electronic Data COVID-19 Observational Study,2023-03-27
+phs002694.v1.p1,c1,Accelerating COVID-19 Therapeutic Interventions and Vaccines 4 ACUTE (ACTIV-4A),2023-03-27
+phs002710.v1.p1,c1,COVID-19 Positive Outpatient Thrombosis Prevention in Adults Aged 40-80,2023-03-27
+phs002752.v1.p1,c1,Clinical-trial of COVID-19 Convalescent Plasma in Outpatients,2023-03-27


### PR DESCRIPTION
This PR adds the list of dbGaP identifiers that should be loaded into BDC Dug (https://renci.atlassian.net/browse/DUG-223?focusedCommentId=10809) to this repository, as well as a Bash script that can be used to download all these files. I kept running into errors with the FTP download command, but luckily dbGaP is simultaneously available over HTTPS, so this script now uses FTP to list all the data dictionaries in an FTP folder, and then uses HTTPS (via the Requests library) to actually download the files.

I know this is pretty messy, so please don't be shy about telling me specific pieces I should unmessify further! This should be pretty similar to the previous download, but if there are any significant differences and the downloaded dbGaP files can't be ingested by Roger, let me know and I'll fix it here.