### PR TITLE
Add a Dug Dumper

### DIFF
--- a/bin/dug_dumper.py
+++ b/bin/dug_dumper.py
@@ -1,0 +1,20 @@
+"""
+The Dug Dumper allows you to dump certain kinds of content from a Dug instance.
+"""
+
+import click
+
+@click.command()
+@click.argument('output', type=click.Path(exists=False), required=True)
+@click.option('--mds-metadata-endpoint', '--mds', default=DEFAULT_MDS_ENDPOINT,
+              help='The MDS metadata endpoint to use, e.g. https://healdata.org/mds/metadata')
+@click.option('--limit', default=MDS_DEFAULT_LIMIT, help='The maximum number of entries to retrieve from the Platform '
+                                                         'MDS. Note that some MDS instances have their own built-in '
+                                                         'limit; if you hit that limit, you will need to update the '
+                                                         'code to support offsets.')
+def dug_dumper():
+    pass
+
+# Run dug_dumper() if not used as a library.
+if __name__ == "__main__":
+    dug_dumper()


### PR DESCRIPTION
This PR is intended to add a command line tool that can be used to retrieve lists of categories, studies, variables and CDEs from a Dug instance. The idea is to be able to use this one-off to test whether a dataset has been correctly and fully loaded into Dug, and maybe eventually to use it for integration testing to make sure 