### PR TITLE
Hacky fix to the e_link issue for CDEs

### DIFF
--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -417,11 +417,8 @@ class Search:
             # as a list of CDE links.
             if elem_s['element_action']:
                 e_link = elem_s['element_action']
-            elif elem_s['collection_action']:
-                if isinstance(elem_s['collection_action'], list):
-                    e_link = elem_s['collection_action'][0]
-                else:
-                    e_link = elem_s['collection_action']
+            elif elem_s['collection_action'] and elem_id.startswith('HEALCDE:') and isinstance(elem_s['collection_action'], list):
+                e_link = elem_s['collection_action'][0]
 
             elem_id = elem_s['element_id']
             coll_id = elem_s['collection_id']

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -413,11 +413,21 @@ class Search:
             if elem_type not in new_results:
                 new_results[elem_type] = {}
 
+            # For CDEs, our data model is a bit weird, so the e_link is actually in the c_link field
+            # as a list of CDE links.
+            if elem_s['element_action']:
+                e_link = elem_s['element_action']
+            elif elem_s['collection_action']:
+                if isinstance(elem_s['collection_action'], list):
+                    e_link = elem_s['collection_action'][0]
+                else:
+                    e_link = elem_s['collection_action']
+
             elem_id = elem_s['element_id']
             coll_id = elem_s['collection_id']
             elem_info = {
                 "description": elem_s['element_desc'],
-                "e_link": elem_s['element_action'],
+                "e_link": e_link,
                 "id": elem_id,
                 "name": elem_s['element_name'],
                 "score": round(elem['_score'], 6)


### PR DESCRIPTION
HEAL CDEs have multiple outgoing links: they should always link to an XLSX file that describes the CDE, they may link to Word/PDF files in multiple languages, and hopefully at some point it will be possible to link directly to the CDE on the HEAL CDE repository (you can kinda do that now by doing a text search, e.g. https://heal.nih.gov/data/common-data-elements-repository?combine=GAD-2). All of this information is provided to Dug in KGX files by the HEAL CDE importer (https://github.com/heal-data-stewards/heal-cdes/pull/21).

At the moment, Dug's API doesn't return a link for a CDE in the `e_link` (element link) field, which sits alongside the other CDE information (name, description, etc.). Instead, it provides a list of all the URLs in the `c_link` (collection link) field. This PR implements a hacky solution to this problem: for HEAL CDE elements only, if the `e_link` is empty and the `c_link` is a list, it fills in the `e_link` with the first item from the `c_link`.

WIP: actually, this isn't a complete solution, because the `c_link` is shared across all the elements, and is only populated with the data from the first element. So this will actually need diving into the KGX loading code to figure out.