### PR TITLE
Added CORSMiddleware to allow Dug to make CORS requests

### DIFF
--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -3,6 +3,7 @@ import os
 import uvicorn
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from dug.config import Config
 from dug.core.async_search import Search
 from pydantic import BaseModel
@@ -15,6 +16,13 @@ APP = FastAPI(
     root_path=os.environ.get("ROOT_PATH", "/"),
 )
 
+APP.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 class GetFromIndex(BaseModel):
     index: str = "concepts_index"


### PR DESCRIPTION
While working with Dug locally, I noticed that it doesn't provide CORS headers (presumably because it expects Kubernetes to do this). Since the API is intended to be used by anybody, I thought it wouldn't hurt to add CORSMiddleware to explicitly allow all direct API requests from browsers, but this is not my area of expertise, so please feel free to ignore this if this isn't ideal or if there is a better way to do this.