### PR TITLE
Sorted lists for json serialization for parser and annotator outputs DUG-408

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -18,7 +18,7 @@ on:
       - .dockerignore
       - .githooks
     tags-ignore:
-      - 'v[0-9]+.[0-9]+.*'
+      - '*'
 jobs:
   build-push-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -66,45 +66,6 @@ jobs:
       # flake8 --ignore=E,W --exit-zero . 
       continue-on-error: true
 
-# ############################## build-vuln-test ##############################
-  # build-vuln-test:
-  #   # needs: flake8-linter
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-
-  #   - name: Set up Docker Buildx
-  #     uses: docker/setup-buildx-action@v3
-  #     with:
-  #       driver-opts: |
-  #         network=host
-
-  #   - name: Login to DockerHub
-  #     uses: docker/login-action@v3
-  #     with:
-  #       username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #       password: ${{ secrets.DOCKERHUB_TOKEN }}
-  #       logout: true
-
-  #   # Notes on Cache: 
-  #   # https://docs.docker.com/build/ci/github-actions/examples/#inline-cache
-  #   - name: Build Container
-  #     uses: docker/build-push-action@v5
-  #     with:
-  #       context: .
-  #       push: false
-  #       load: true
-  #       tag: ${{ github.repository }}:vuln-test
-  #       cache-from: type=registry,ref=${{ github.repository }}:buildcache
-  #       cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
-  #   ####### Run for Fidelity ######
-  #   - name: Run Trivy vulnerability scanner
-  #     uses: aquasecurity/trivy-action@master
-  #     with:
-  #       image-ref: '${{ github.repository }}:vuln-test'
-  #       severity: 'CRITICAL,HIGH'
-  #       exit-code: '1'
-
 ################################### PYTEST ###################################
   pytest:
     runs-on: ubuntu-latest
@@ -145,3 +106,47 @@ jobs:
     - name: Test with Bandit
       run: |
         bandit -r src -n3 -lll
+
+############################## test-image-build ##############################
+  test-image-build:
+    runs-on: ubuntu-latest
+    # if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set short git commit SHA
+      id: vars
+      run: |
+        echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
+    # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+
+    - name: Confirm git commit SHA output
+      run: echo ${{ steps.vars.outputs.short_sha }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        logout: true
+
+    - name: Parse Github Reference Name
+      id: branch
+      run: |
+        REF=${{ github.ref_name }}
+        echo "GHR=${REF%/*}" >> $GITHUB_OUTPUT
+        
+    # Notes on Cache: 
+    # https://docs.docker.com/build/ci/github-actions/examples/#inline-cache
+    - name: Build Container
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: |
+          ${{ github.repository }}:test_${{ steps.branch.outputs.GHR }}
+        cache-from: type=registry,ref=${{ github.repository }}:buildcache
+        cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max

--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -50,7 +50,7 @@ jobs:
 
     # We will not be concerned with Medium and Low vulnerabilities
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@v0.16.0
+      uses: aquasecurity/trivy-action@master
       with:
         image-ref: '${{ github.repository }}:vuln-test'
         format: 'sarif'

--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -45,8 +45,8 @@ jobs:
         push: false
         load: true
         tags: ${{ github.repository }}:vuln-test
-        # cache-from: type=registry,ref=${{ github.repository }}:buildcache
-        # cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
+        cache-from: type=registry,ref=${{ github.repository }}:buildcache
+        cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
 
     # We will not be concerned with Medium and Low vulnerabilities
     - name: Run Trivy vulnerability scanner

--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -45,8 +45,8 @@ jobs:
         push: false
         load: true
         tags: ${{ github.repository }}:vuln-test
-        cache-from: type=registry,ref=${{ github.repository }}:buildcache
-        cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
+        # cache-from: type=registry,ref=${{ github.repository }}:buildcache
+        # cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
 
     # We will not be concerned with Medium and Low vulnerabilities
     - name: Run Trivy vulnerability scanner

--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -50,7 +50,7 @@ jobs:
 
     # We will not be concerned with Medium and Low vulnerabilities
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.16.0
       with:
         image-ref: '${{ github.repository }}:vuln-test'
         format: 'sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # A container for the core semantic-search capability.
 #
 ######################################################
-FROM python:3.12.0-alpine3.18
+FROM python:alpine3.19
 
 # Install required packages
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # A container for the core semantic-search capability.
 #
 ######################################################
-FROM python:3.12.1-alpine3.18
+FROM python:3.11-alpine
 
 # Install required packages
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # A container for the core semantic-search capability.
 #
 ######################################################
-FROM python:3.11-alpine
+FROM python:3.12.0-alpine3.18
 
 # Install required packages
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # A container for the core semantic-search capability.
 #
 ######################################################
-FROM python:alpine3.19
+FROM python:3.11-alpine3.19
 
 # Install required packages
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # A container for the core semantic-search capability.
 #
 ######################################################
-FROM python:3.12.0-alpine3.18
+FROM python:3.12.1-alpine3.18
 
 # Install required packages
 RUN apk update && \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
   ##
   #################################################################################
   redis:
-    image: 'redis/redis-stack:6.2.14'
+    image: 'redis/redis-stack:6.2.4-v2'
     networks:
       - dug-network
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
   ##
   #################################################################################
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
     networks:
       - dug-network
     environment:
@@ -76,7 +76,7 @@ services:
   ##
   #################################################################################
   redis:
-    image: 'redis/redis-stack:6.2.4-v2'
+    image: 'redis/redis-stack:6.2.14'
     networks:
       - dug-network
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ elasticsearch[async]==8.5.2
 gunicorn
 itsdangerous
 Jinja2
+jsonpickle
 jsonschema
 MarkupSafe
 ormar

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.12
+python_requires = >=3.11
 include_package_data = true
 install_requires =
     elasticsearch==8.5.2

--- a/src/dug/core/annotators/_base.py
+++ b/src/dug/core/annotators/_base.py
@@ -15,15 +15,26 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 class DugIdentifier:
-    """ The Dug Identifier is the core piece of information about a concept that produced from a request to an annotator based on a some original source of data. 
-    \n The information that is being stored is mostly meant to support the Monarch API but should be adjusted accordingly to suit new Annotators needs in the future.
+    """Core information about a concept, produced from annotator request
+
+    The Dug Identifier is the core piece of information about a concept that
+    produced from a request to an annotator based on a some original source of
+    data.
+
+    \n The information that is being stored is mostly meant to support the
+    Monarch API but should be adjusted accordingly to suit new Annotators needs
+    in the future.
     \n The information that will be needed for all annotators are:
         \n id: The CURIE identifier
         \n label: The CURIE identifier
         \n description: The CURIE identifier
-    \n When there is another supported Normalizer it will be seperated into a separate plugin like annotator.
+    \n When there is another supported Normalizer it will be seperated into a
+    separate plugin like annotator.
     """
+
     def __init__(self, id, label, types=None, search_text="", description=""):
+        "custom init stores parameters to initial values"
+
         self.id = id
         self.label = label
         self.description = description
@@ -40,12 +51,12 @@ class DugIdentifier:
         return self.id.split(":")[0]
 
     def add_search_text(self, text):
-        # Add text only if it's unique and if not empty string
+        "Add text only if it's unique and if not empty string"
         if text and text not in self.search_text:
             self.search_text.append(text)
 
     def get_searchable_dict(self):
-        # Return a version of the identifier compatible with what's in ElasticSearch
+        "Return version of identifier compatible with what's in ElasticSearch"
         es_ident = {
             "id": self.id,
             "label": self.label,
@@ -56,7 +67,13 @@ class DugIdentifier:
         return es_ident
 
     def jsonable(self):
-        return self.__dict__
+        "Output pickleable object (used by utils.complex_handler)"
+        outdict = self.__dict__
+
+        outdict['search_text'] = sorted(self.search_text)
+        outdict['synonyms'] = sorted(self.synonyms)
+
+        return outdict
 
     def __str__(self):
         return json.dumps(self.__dict__, indent=2, default=utils.complex_handler)
@@ -82,9 +99,18 @@ class AnnotatorSession(Generic[Input, Output]):
 
 
 class DefaultNormalizer():
-    """ After annotation there must be a Noramlizing step to collasce equivalent concepts into one official concept. This is a needed step for the knowledge graph to map between different concepts.
-    \n The reason why this class in integrated into the annotators.py is because currently there is only one supported Normalizer through the NCATs Translator API.
-    \n When there is another supported Normalizer it will be seperated into a separate plugin like annotator.
+    """Default concept normalizer class
+
+    After annotation there must be a Normalizing step to collasce equivalent
+    concepts into one official concept. This is a needed step for the knowledge
+    graph to map between different concepts.
+
+    The reason why this class in integrated into the annotators.py is because
+    currently there is only one supported Normalizer through the NCATs
+    Translator API.
+
+    When there is another supported Normalizer it will be seperated into a
+    separate plugin like annotator.
     """
 
     def __init__(self, url):

--- a/src/dug/core/annotators/_base.py
+++ b/src/dug/core/annotators/_base.py
@@ -41,7 +41,7 @@ class DugIdentifier:
         if types is None:
             types = []
         self.types = types
-        self.search_text = [search_text] if search_text else []
+        self.search_text = sorted([search_text]) if search_text else []
         self.equivalent_identifiers = []
         self.synonyms = []
         self.purl = ""
@@ -53,7 +53,7 @@ class DugIdentifier:
     def add_search_text(self, text):
         "Add text only if it's unique and if not empty string"
         if text and text not in self.search_text:
-            self.search_text.append(text)
+            self.search_text = sorted(self.search_text + [text])
 
     def get_searchable_dict(self):
         "Return version of identifier compatible with what's in ElasticSearch"
@@ -68,12 +68,8 @@ class DugIdentifier:
 
     def jsonable(self):
         "Output pickleable object (used by utils.complex_handler)"
-        outdict = self.__dict__
+        return self.__dict__
 
-        outdict['search_text'] = sorted(self.search_text)
-        outdict['synonyms'] = sorted(self.synonyms)
-
-        return outdict
 
     def __str__(self):
         return json.dumps(self.__dict__, indent=2, default=utils.complex_handler)

--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -29,7 +29,18 @@ class DugElement:
         self.concepts[concept.id] = concept
 
     def jsonable(self):
-        return self.__dict__
+        """Output a pickleable object
+
+        used by dug.utils.complex_handler. Because search_terms and
+        optional_terms are considered unsorted lists by the parsers but will be
+        treated as sorted lists by python, sorting the lists before output
+        prevents changes in ordering from being treated as a change in output by
+        incremental change detection.
+        """
+        outdict = self.__dict__
+        outdict['search_terms'] = sorted(self.search_terms)
+        outdict['optional_terms'] = sorted(self.optional_terms)
+        return outdict
 
     def get_searchable_dict(self):
         # Translate DugElement to ES-style dict
@@ -132,7 +143,18 @@ class DugConcept:
         return es_conc
 
     def jsonable(self):
-        return self.__dict__
+        """Output a pickleable object
+
+        used by dug.utils.complex_handler. Because search_terms and
+        optional_terms are considered unsorted lists by the parsers but will be
+        treated as sorted lists by python, sorting the lists before output
+        prevents changes in ordering from being treated as a change in output by
+        incremental change detection.
+        """
+        outdict = self.__dict__
+        outdict['search_terms'] = sorted(self.search_terms)
+        outdict['optional_terms'] = sorted(self.optional_terms)
+        return outdict
 
     def __str__(self):
         return json.dumps(self.__dict__, indent=2, default=utils.complex_handler)

--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -29,18 +29,8 @@ class DugElement:
         self.concepts[concept.id] = concept
 
     def jsonable(self):
-        """Output a pickleable object
-
-        used by dug.utils.complex_handler. Because search_terms and
-        optional_terms are considered unsorted lists by the parsers but will be
-        treated as sorted lists by python, sorting the lists before output
-        prevents changes in ordering from being treated as a change in output by
-        incremental change detection.
-        """
-        outdict = self.__dict__
-        outdict['search_terms'] = sorted(self.search_terms)
-        outdict['optional_terms'] = sorted(self.optional_terms)
-        return outdict
+        """Output a pickleable object"""
+        return self.__dict__
 
     def get_searchable_dict(self):
         # Translate DugElement to ES-style dict
@@ -66,7 +56,7 @@ class DugElement:
             concept.set_search_terms()
             search_terms.extend(concept.search_terms)
             search_terms.append(concept.name)
-        search_terms = list(set(search_terms))
+        search_terms = sorted(list(set(search_terms)))
         self.search_terms = search_terms
 
     def set_optional_terms(self):
@@ -74,7 +64,7 @@ class DugElement:
         for concept_id, concept in self.concepts.items():
             concept.set_optional_terms()
             optional_terms.extend(concept.optional_terms)
-        optional_terms = list(set(optional_terms))
+        optional_terms = sorted(list(set(optional_terms)))
         self.optional_terms = optional_terms
 
     def __str__(self):
@@ -110,15 +100,15 @@ class DugConcept:
             self.kg_answers[answer_id] = answer
 
     def clean(self):
-        self.search_terms = list(set(self.search_terms))
-        self.optional_terms = list(set(self.optional_terms))
+        self.search_terms = sorted(list(set(self.search_terms)))
+        self.optional_terms = sorted(list(set(self.optional_terms)))
 
     def set_search_terms(self):
         # Traverse set of identifiers to determine set of search terms
         search_terms = self.search_terms
         for ident_id, ident in self.identifiers.items():
             search_terms.extend(ident.search_text + ident.synonyms)
-        self.search_terms = list(set(search_terms))
+        self.search_terms = sorted(list(set(search_terms)))
 
     def set_optional_terms(self):
         # Traverse set of knowledge graph answers to determine set of optional search terms
@@ -126,7 +116,7 @@ class DugConcept:
         for kg_id, kg_answer in self.kg_answers.items():
             optional_terms += kg_answer.get_node_names()
             optional_terms += kg_answer.get_node_synonyms()
-        self.optional_terms = list(set(optional_terms))
+        self.optional_terms = sorted(list(set(optional_terms)))
 
     def get_searchable_dict(self):
         # Translate DugConcept into Elastic-Compatible Concept
@@ -143,18 +133,8 @@ class DugConcept:
         return es_conc
 
     def jsonable(self):
-        """Output a pickleable object
-
-        used by dug.utils.complex_handler. Because search_terms and
-        optional_terms are considered unsorted lists by the parsers but will be
-        treated as sorted lists by python, sorting the lists before output
-        prevents changes in ordering from being treated as a change in output by
-        incremental change detection.
-        """
-        outdict = self.__dict__
-        outdict['search_terms'] = sorted(self.search_terms)
-        outdict['optional_terms'] = sorted(self.optional_terms)
-        return outdict
+        """Output a pickleable object"""
+        return self.__dict__
 
     def __str__(self):
         return json.dumps(self.__dict__, indent=2, default=utils.complex_handler)


### PR DESCRIPTION
As we try to use LakeFS to avoid re-processing on unnecessary changes, sometimes the output is detected as a change when no real data have changed. This is usually an ordering problem in an unordered list or key:value pair. The below URL has a LakeFS commit that should not have occurred.

https://lakefs.apps.renci.org/repositories/yk-heal/commits/e0739329347be52164815581c3d819cb4712ed5e71d66214e0888b3950c03908?prefix=annotate_and_index%2Fcrdc_dataset_pipeline_task_group.crawl_crdc%2Fphs000178.v11.pht000804.v9.TCGA_Subject.data_dict%2F

A code modification to the JSON output will be needed to fix this, after some investigation.