### PR TITLE
change simple concept search to score based on aggregate relevance

### DIFF
--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -62,7 +62,7 @@ jobs:
     # We still fail the job if results are found, so below will always run
     # unless manually canceled.
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: '!cancelled()'
       with:
         sarif_file: 'trivy-results.sarif'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ MarkupSafe
 ormar
 mistune
 pluggy
+pydantic==2.9.2
 pyrsistent
 pytest
 pytest-asyncio

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -728,16 +728,6 @@ class Search:
     def get_simple_search_query(self, query):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
         More info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html."""
-        search_query = {
-            "query": {
-                "simple_query_string": {
-                    "query": query,
-                    "fields": ["name", "description", "search_terms"],
-                    "default_operator": "and",
-                    "flags": "OR|AND|NOT|PHRASE|PREFIX"
-                },
-            }
-        }
         simple_query_string_search = {
             "query": query,
             "default_operator": "and",

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -735,6 +735,42 @@ class Search:
                     "fields": ["name", "description", "search_terms"],
                     "default_operator": "and",
                     "flags": "OR|AND|NOT|PHRASE|PREFIX"
+                },
+            }
+        }
+        simple_query_string_search = {
+            "query": query,
+            "default_operator": "and",
+            "flags": "OR|AND|NOT|PHRASE|PREFIX"
+        }
+        search_query = {
+            "query": {
+                "function_score": {
+                    "query": {
+                        "bool": {
+                            "should": [
+                                {
+                                    "simple_query_string": {
+                                        **simple_query_string_search,
+                                        "fields": ["name"]
+                                    }
+                                },
+                                {
+                                    "simple_query_string": {
+                                        **simple_query_string_search,
+                                        "fields": ["description"]
+                                    }
+                                },
+                                {
+                                    "simple_query_string": {
+                                        **simple_query_string_search,
+                                        "fields": ["search_terms"]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "score_mode": "sum"
                 }
             }
         }

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -14,7 +14,7 @@ logger = logging.getLogger (__name__)
 
 APP = FastAPI(
     title="Dug Search API",
-    root_path=os.environ.get("ROOT_PATH", "/"),
+    root_path=os.environ.get("ROOT_PATH", ""),
 )
 
 APP.add_middleware(


### PR DESCRIPTION
change simple concept search to use simple_query_string matches against individual fields so that hit score is comptued as aggregate of field match scores, rather than using the field match's score. This change is necessary since score explanation does not make sense when using a disjunctive max scoring.