### PR TITLE
Add JSON Schema export for Dug Data Model v2

### DIFF
--- a/bin/export_ddm_as_json_schema.py
+++ b/bin/export_ddm_as_json_schema.py
@@ -3,7 +3,7 @@
 # export_ddm_as_json_schema.py - Export Dug Data Model as JSON Schema
 #
 # SYNOPSIS
-#   python bin/export_ddm_as_json_schema.py
+#   PYTHONPATH=src python bin/export_ddm_as_json_schema.py
 #
 
 import click

--- a/bin/export_ddm_as_json_schema.py
+++ b/bin/export_ddm_as_json_schema.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# export_ddm_as_json_schema.py - Export Dug Data Model as JSON Schema
+#
+# SYNOPSIS
+#   python bin/export_ddm_as_json_schema.py
+#
+
+import click
+import json
+import logging
+
+from dug.core.parsers._base import DugStudy, DugSection, DugVariable
+
+logging.basicConfig(level=logging.INFO)
+
+@click.command()
+def export_ddm_as_json_schema():
+    """
+
+    :return:
+    """
+    logging.info("Exporting Dug Data Model as JSON Schema")
+
+    json_schema = {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+            # This is what Pydantic supports: https://docs.pydantic.dev/latest/api/json_schema/#pydantic.json_schema.GenerateJsonSchema
+        'definitions': {
+            'DugSection': DugSection.model_json_schema(),
+            'DugVariable': DugVariable.model_json_schema(),
+            'DugStudy': DugStudy.model_json_schema()
+        },
+        # We want to validate a list of heterogenous objects: each item in the list may be any of the Dug objects above.
+        'type': 'list',
+        'items': {
+            'oneOf': [
+                {'$ref': '#/definitions/DugSection'},
+                {'$ref': '#/definitions/DugVariable'},
+                {'$ref': '#/definitions/DugStudy'}
+            ]
+        }
+    }
+
+    print(json.dumps(json_schema, indent=2))
+
+
+if __name__ == '__main__':
+    export_ddm_as_json_schema()

--- a/bin/export_ddm_as_json_schema.py
+++ b/bin/export_ddm_as_json_schema.py
@@ -31,7 +31,7 @@ def export_ddm_as_json_schema():
             'DugStudy': DugStudy.model_json_schema()
         },
         # We want to validate a list of heterogenous objects: each item in the list may be any of the Dug objects above.
-        'type': 'list',
+        'type': 'array',
         'items': {
             'oneOf': [
                 {'$ref': '#/definitions/DugSection'},


### PR DESCRIPTION
This PR adds a script that writes out the Dug Data Model v2 as a JSON Schema. Since Pydantic can export a model in JSON Schema, all this does is defines a document as a list of objects, each of which must conform to either a DugStudy, DugSection or a DugVariable.