### PR TITLE
terms of service field

### DIFF
--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -16,6 +16,7 @@ logger = logging.getLogger (__name__)
 APP = FastAPI(
     title="Dug Search API",
     root_path=os.environ.get("ROOT_PATH", ""),
+    terms_of_service=os.environ.get("DUG_TOS_URL", None),
 )
 
 APP.add_middleware(


### PR DESCRIPTION
If DUG_TOS_URL is present as an environment variable, display it in the OpenAPI "terms_of_service" field