### PR TITLE
Model 2.0 filtering

### DIFF
--- a/src/dug/api_models/request_models.py
+++ b/src/dug/api_models/request_models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, field_validator
-from typing import List, Optional, Literal, Union, Any
+from typing import List, Dict, Optional, Literal, Union, Any
 
 class GetFromIndex(BaseModel):
     size: int = 0
@@ -41,6 +41,7 @@ class SearchElementQuery(BaseModel):
     element_ids: Optional[List] = None
     concept: Optional[str] = None
 
+    aggs: Optional[Dict[str, int]] = Field(default=None, description="Specify fields to aggregate against and the bucket limit")
     filters: Optional[List[FilterCriterion]] = Field(default_factory=list)
 
     size: Optional[int] = 100

--- a/src/dug/api_models/request_models.py
+++ b/src/dug/api_models/request_models.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, field_validator
-from typing import List, Optional, Any
+from pydantic import BaseModel, Field, field_validator
+from typing import List, Optional, Literal, Union, Any
 
 class GetFromIndex(BaseModel):
     size: int = 0
@@ -28,11 +28,21 @@ class SearchKgQuery(BaseModel):
     index: str = "kg_index"
     size:int = 100
 
+FilterOperator = Literal["eq", "neq", "gt", "gte", "lt", "lte", "in", "contains"]
+
+class FilterCriterion(BaseModel):
+    field: str = Field(..., description="The metadata field to filter by (e.g., 'is_cde' or 'data_type')")
+    operator: FilterOperator = Field("eq", description="Comparison operator")
+    value: Union[str, int, float, bool, List[Any]] = Field(..., description="The value to filter against")
+
 class SearchElementQuery(BaseModel):
     query: str = None
     parent_ids: Optional[List] = None
     element_ids: Optional[List] = None
     concept: Optional[str] = None
+
+    filters: Optional[List[FilterCriterion]] = Field(default_factory=list)
+
     size: Optional[int] = 100
     offset: Optional[int] = 0
 

--- a/src/dug/api_models/request_models.py
+++ b/src/dug/api_models/request_models.py
@@ -28,7 +28,15 @@ class SearchKgQuery(BaseModel):
     index: str = "kg_index"
     size:int = 100
 
-FilterOperator = Literal["eq", "neq", "gt", "gte", "lt", "lte", "in", "contains"]
+FilterOperator = Literal[
+    "eq", "neq",
+    "gt", "gte",
+    "lt", "lte",
+    "in", "contains",
+    "size_eq",
+    "size_gt", "size_gte",
+    "size_lt", "size_lte"
+]
 
 class FilterCriterion(BaseModel):
     field: str = Field(..., description="The metadata field to filter by (e.g., 'is_cde' or 'data_type')")

--- a/src/dug/api_models/request_models.py
+++ b/src/dug/api_models/request_models.py
@@ -32,7 +32,8 @@ FilterOperator = Literal[
     "eq", "neq",
     "gt", "gte",
     "lt", "lte",
-    "in", "contains",
+    "in",
+    "exists", "missing",
     "size_eq",
     "size_gt", "size_gte",
     "size_lt", "size_lte"
@@ -41,7 +42,7 @@ FilterOperator = Literal[
 class FilterCriterion(BaseModel):
     field: str = Field(..., description="The metadata field to filter by (e.g., 'is_cde' or 'data_type')")
     operator: FilterOperator = Field("eq", description="Comparison operator")
-    value: Union[str, int, float, bool, List[Any]] = Field(..., description="The value to filter against")
+    value: Optional[Union[str, int, float, bool, List[Any]]] = Field(default=None, description="The value to filter against")
 
 class SearchElementQuery(BaseModel):
     query: str = None

--- a/src/dug/api_models/response_models.py
+++ b/src/dug/api_models/response_models.py
@@ -32,10 +32,8 @@ class ConceptResponse(ElasticDugElementResult, DugConcept):
     concepts: None = Field(default=None, exclude=True)
 
 
-class ConceptsAPIResponse(BaseModel):
-    metadata: ElasticResultMetaData
+class ConceptsAPIResponse(DugAPIResponse):
     results: List[ConceptResponse]
-    concept_types: dict = Field(default="")
 
 
 class VariableResponse(ElasticDugElementResult, DugVariable):

--- a/src/dug/api_models/response_models.py
+++ b/src/dug/api_models/response_models.py
@@ -1,12 +1,16 @@
 from dug.core.parsers._base import *
 from pydantic import BaseModel, model_serializer
-from typing import Optional, Any
+from typing import Optional, Any, List
 
 
 class ElasticResultMetaData(BaseModel):
     total_count: int
     offset: int
     size: int
+
+class ElasticAggregationBucket(BaseModel):
+    key: str
+    count: int
 
 
 class ElasticDugElementResult(BaseModel):
@@ -20,6 +24,7 @@ class ElasticDugElementResult(BaseModel):
 class DugAPIResponse(BaseModel):
     results: List[ElasticDugElementResult]
     metadata: Optional[ElasticResultMetaData] = Field(default_factory=dict)
+    aggregations: Optional[Dict[str, List[ElasticAggregationBucket]]] = Field(default=None)
 
 
 class ConceptResponse(ElasticDugElementResult, DugConcept):

--- a/src/dug/config.py
+++ b/src/dug/config.py
@@ -37,6 +37,7 @@ class Config:
     studies_index_name: str='studies_index'
     sections_index_name: str='sections_index'
 
+    default_page_size: int = 100
     # Limit the size of arbitrary elasticsearch aggregations (expensive)
     aggregate_size_limit: int = 200
 
@@ -172,6 +173,7 @@ class Config:
             "variables_index_name": "ELASTIC_VARIABLES_INDEX_NAME",
             "studies_index_name": "ELASTIC_STUDIES_INDEX_NAME",
             "sections_index_name": "ELASTIC_SECTIONS_INDEX_NAME",
+            "default_page_size": "DEFAULT_PAGE_SIZE",
             "aggregate_size_limit": "AGGREGATE_SIZE_LIMIT"
         }
         kwargs = {}

--- a/src/dug/config.py
+++ b/src/dug/config.py
@@ -37,6 +37,9 @@ class Config:
     studies_index_name: str='studies_index'
     sections_index_name: str='sections_index'
 
+    # Limit the size of arbitrary elasticsearch aggregations (expensive)
+    aggregate_size_limit: int = 200
+
     # Preprocessor config that will be passed to annotate.Preprocessor constructor
     preprocessor: dict = field(
         default_factory=lambda: {
@@ -169,6 +172,7 @@ class Config:
             "variables_index_name": "ELASTIC_VARIABLES_INDEX_NAME",
             "studies_index_name": "ELASTIC_STUDIES_INDEX_NAME",
             "sections_index_name": "ELASTIC_SECTIONS_INDEX_NAME",
+            "aggregate_size_limit": "AGGREGATE_SIZE_LIMIT"
         }
         kwargs = {}
         for kwarg, env_var in env_vars.items():

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -330,6 +330,7 @@ class Search:
                                   query="",
                                   parent_ids=None,
                                   element_ids=None,
+                                  filters=[],
                                   size=None,
                                   offset=0,
                                   fuzziness=1,
@@ -340,11 +341,13 @@ class Search:
                                                              query=query,
                                                              parent_ids=parent_ids,
                                                              element_ids=element_ids,
+                                                             filters=filters,
                                                              new_model=True)
         else:
             es_query = self._get_element_search_query(concept=concept,
                                                       parent_ids=parent_ids,
                                                       element_ids=element_ids,
+                                                      filters=filters,
                                                       fuzziness=fuzziness,
                                                       prefix_length=prefix_length,
                                                       query=query,
@@ -694,13 +697,55 @@ class Search:
             return program_summary
 
     @staticmethod
+    def _convert_filters_to_es(filters):
+        """
+        Converts a list of FilterCriterion dicts into ElasticSearch DSL dicts.
+        """
+        if not filters:
+            return []
+            
+        es_filters = []
+        for f in filters:
+            # Support both Pydantic model and dumped dict format
+            field = getattr(f, "field", f.get("field"))
+            operator = getattr(f, "operator", f.get("operator"))
+            value = getattr(f, "value", f.get("value"))
+
+            if operator == "eq":
+                es_filters.append({"term": { field: value }})
+            elif operator == "neq":
+                es_filters.append({
+                    "bool": {
+                        "must_not": [{ "term": { field: value } }]
+                    }
+                })
+            elif operator == "in":
+                val = value if isinstance(value, list) else [value]
+                es_filters.append({"terms": { field: val }})
+            elif operator in ["gt", "gte", "lt", "lte"]:
+                es_filters.append({"range": { field: { operator: value } }})
+            elif operator == "contains":
+                es_filters.append({"wildcard": { field: f"*{value}*" }})
+            elif operator == "exists":
+                es_filters.append({"exists": { "field": field }})
+            elif operator == "missing":
+                es_filters.append({"bool": {
+                    "must_not": [
+                        {"exists": {"field": field}}
+                    ]}
+                })
+                
+        return es_filters
+
+    @staticmethod
     def _get_element_search_query(concept,
                                   fuzziness,
                                   prefix_length,
                                   query,
                                   new_model=False,
                                   element_ids=None,
-                                  parent_ids=None):
+                                  parent_ids=None,
+                                  filters=[]):
         """Returns ES query for variable search"""
         element_name = "element_name"
         element_desc = "element_desc"
@@ -810,7 +855,8 @@ class Search:
                                 }
                             }
                         }
-                    ]
+                    ],
+                    'filter': Search._convert_filters_to_es(filters) if filters else []
                 }
             }
         }
@@ -914,7 +960,14 @@ class Search:
         return search_query
 
     @staticmethod
-    def _get_element_simple_search_query(concept, query, new_model=False, parent_ids=None, element_ids=None):
+    def _get_element_simple_search_query(
+        concept,
+        query,
+        new_model=False,
+        parent_ids=None,
+        element_ids=None,
+        filters=[]
+    ):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
         More info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html."""
         simple_query_string_search = {
@@ -963,7 +1016,8 @@ class Search:
                             },
                             "score_mode": "sum"
                         }}
-                    ]
+                    ],
+                    "filter": Search._convert_filters_to_es(filters) if filters else []
                 }
             }
         }

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -359,17 +359,18 @@ class Search:
                                                       new_model=True
                                                       )
 
-        total_items = (await self.es.count(body={ "query": es_query["query"] }, index=index_name))['count']
         search_results = await self.es.search(
             index=index_name,
             body=es_query,
             filter_path=['hits.hits._id', 'hits.hits._type',
-                         'hits.hits._source', 'hits.hits._score', 'aggregations'],
+                         'hits.hits._source', 'hits.hits._score', 'hits.total', 'aggregations'],
             from_=offset,
-            size=size or total_items
+            size=size or self._cfg.default_page_size
         )
 
+        total_items = search_results["hits"]["total"]["value"]
         search_result_hits = self.remove_hits_from_results(search_results)
+        
         formatted_aggs = {}
         if "aggregations" in search_results:
             for field_name, agg_data in search_results["aggregations"].items():

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -236,7 +236,7 @@ class Search:
             return False
         return "*" in query or "\"" in query or "+" in query or "-" in query
 
-    async def search_concepts(self, query, offset=0, size=None, concept_types=None, **kwargs):
+    async def search_concepts(self, query, offset=0, size=None, concept_types=None, filters=None, **kwargs):
         """
         Changed to a long boolean match query to optimize search results
         """
@@ -330,7 +330,8 @@ class Search:
                                   query="",
                                   parent_ids=None,
                                   element_ids=None,
-                                  filters=[],
+                                  filters=None,
+                                  aggs=None,
                                   size=None,
                                   offset=0,
                                   fuzziness=1,
@@ -342,31 +343,43 @@ class Search:
                                                              parent_ids=parent_ids,
                                                              element_ids=element_ids,
                                                              filters=filters,
+                                                             aggs=aggs,
+                                                             aggregate_size_limit=self._cfg.aggregate_size_limit,
                                                              new_model=True)
         else:
             es_query = self._get_element_search_query(concept=concept,
                                                       parent_ids=parent_ids,
                                                       element_ids=element_ids,
                                                       filters=filters,
+                                                      aggs=aggs,
+                                                      aggregate_size_limit=self._cfg.aggregate_size_limit,
                                                       fuzziness=fuzziness,
                                                       prefix_length=prefix_length,
                                                       query=query,
                                                       new_model=True
                                                       )
 
-        total_items = (await self.es.count(body=es_query, index=index_name))['count']
+        total_items = (await self.es.count(body={ "query": es_query["query"] }, index=index_name))['count']
         search_results = await self.es.search(
             index=index_name,
             body=es_query,
             filter_path=['hits.hits._id', 'hits.hits._type',
-                         'hits.hits._source', 'hits.hits._score'],
+                         'hits.hits._source', 'hits.hits._score', 'aggregations'],
             from_=offset,
             size=size or total_items
         )
 
         search_result_hits = self.remove_hits_from_results(search_results)
+        formatted_aggs = {}
+        if "aggregations" in search_results:
+            for field_name, agg_data in search_results["aggregations"].items():
+                buckets = agg_data.get("buckets", [])
+                formatted_aggs[field_name] = [
+                    { "key": str(bucket["key"]), "count": bucket["doc_count"] }
+                    for bucket in buckets
+                ]
 
-        return search_result_hits, total_items
+        return search_result_hits, total_items, formatted_aggs
 
     async def search_vars_unscored(self, concept="", query="",
                                    size=None, data_type=None,
@@ -745,7 +758,9 @@ class Search:
                                   new_model=False,
                                   element_ids=None,
                                   parent_ids=None,
-                                  filters=[]):
+                                  filters=None,
+                                  aggs=None,
+                                  aggregate_size_limit=None):
         """Returns ES query for variable search"""
         element_name = "element_name"
         element_desc = "element_desc"
@@ -855,8 +870,7 @@ class Search:
                                 }
                             }
                         }
-                    ],
-                    'filter': Search._convert_filters_to_es(filters) if filters else []
+                    ]
                 }
             }
         }
@@ -902,6 +916,25 @@ class Search:
                         }
                     }
                 )
+
+        if filters:
+            post_filter = es_query \
+                .setdefault("post_filter", {}) \
+                .setdefault("bool", {}) \
+                .setdefault("filter", [])
+            post_filter.extend(Search._convert_filters_to_es(filters))
+
+        if aggs:
+            es_query["aggs"] = {}
+            for field, size_limit in aggs.items():
+                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
+                es_query["aggs"][field] = {
+                    "terms": {
+                        "field": field,
+                        "size": size
+                    }
+                }
+
 
         return es_query
 
@@ -966,7 +999,9 @@ class Search:
         new_model=False,
         parent_ids=None,
         element_ids=None,
-        filters=[]
+        filters=None,
+        aggs=None,
+        aggregate_size_limit=None
     ):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
         More info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html."""
@@ -1016,8 +1051,7 @@ class Search:
                             },
                             "score_mode": "sum"
                         }}
-                    ],
-                    "filter": Search._convert_filters_to_es(filters) if filters else []
+                    ]
                 }
             }
         }
@@ -1064,6 +1098,26 @@ class Search:
                         }
                     }
                 )
+
+        if filters:
+            post_filter = search_query \
+                .setdefault("post_filter", {}) \
+                .setdefault("bool", {}) \
+                .setdefault("filter", [])
+            post_filter.extend(Search._convert_filters_to_es(filters))
+            
+        if aggs:
+            search_query["aggs"] = {}
+            for field, size_limit in aggs.items():
+                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
+                search_query["aggs"][field] = {
+                    "terms": {
+                        "field": field,
+                        "size": size
+                    }
+                }
+
+
         return search_query
 
     async def get_elements_by_ids(self, ids: [str], index_name=""):

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -240,7 +240,9 @@ class Search:
                 .setdefault("post_filter", {}) \
                 .setdefault("bool", {}) \
                 .setdefault("filter", [])
-            post_filter.extend(Search._convert_filters_to_es(filters))
+            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
+            post_filter.extend(es_filters)
+            query_object.setdefault("runtime_mappings", {}).update(es_rt_mappings)
 
         if aggs:
             query_object["aggs"] = {}
@@ -361,7 +363,7 @@ class Search:
                               fuzziness=1,
                               prefix_length=3,
                               explain=False):
-        is_concepts_search = index_name == self._cfg.concepts_index_name
+        is_concepts_search = index_name == self.indices["concepts_index"]
         is_simple_search = self.is_simple_search_query(query)
 
         if is_concepts_search:
@@ -407,16 +409,20 @@ class Search:
                     new_model=True
                 )
 
-        search_results = await self.es.search(
-            index=index_name,
-            body=es_query,
-            filter_path=['hits.hits._id', 'hits.hits._type',
-                         'hits.hits._source', 'hits.hits._score', 'hits.total',
-                         'hits.hits._explanation', 'aggregations'],
-            explain=explain,
-            from_=offset,
-            size=size or self._cfg.default_page_size
-        )
+        try:
+            search_results = await self.es.search(
+                index=index_name,
+                body=es_query,
+                filter_path=['hits.hits._id', 'hits.hits._type',
+                            'hits.hits._source', 'hits.hits._score', 'hits.total',
+                            'hits.hits._explanation', 'aggregations'],
+                explain=explain,
+                from_=offset,
+                size=size or self._cfg.default_page_size
+            )
+        except Exception as e:
+            print(e.body)
+            raise e
 
         total_items = search_results["hits"]["total"]["value"]
         search_result_hits = self.remove_hits_from_results(search_results)
@@ -766,9 +772,10 @@ class Search:
         Converts a list of FilterCriterion dicts into ElasticSearch DSL dicts.
         """
         if not filters:
-            return []
+            return [], {}
             
         es_filters = []
+        runtime_mappings = {}
         for f in filters:
             # Support both Pydantic model and dumped dict format
             field = getattr(f, "field", f.get("field"))
@@ -797,22 +804,46 @@ class Search:
                     ]}
                 })
             elif operator.startswith("size"):
-                op_map = {
-                    "size_eq": "==",
-                    "size_gt": ">",
-                    "size_gte": ">=",
-                    "size_lt": "<",
-                    "size_lte": "<="
-                }
-                symbol = op_map[operator]
-                es_filters.append({"script": {
-                    "script": {
-                        "source": f"doc['{ field }'].size() { symbol } params.val",
-                        "params": { "val": int(value) }
+                _, es_operator = operator.split("_")
+                runtime_field_name = f"{field}_calculated_size"
+                script_source = """
+                    def path = /\\./.split(params.field);
+                    def obj = params._source;
+                    for (part in path) {
+                        if (obj == null) break;
+                        obj = obj[part];
                     }
-                }})
+                    if (obj instanceof Map) {
+                        emit(obj.size());
+                    } else if (obj instanceof List) {
+                        emit(obj.size());
+                    } else {
+                        emit(0);
+                    }
+                """
+                runtime_mappings[runtime_field_name] = {
+                    "type": "long",
+                    "script": {
+                        "source": script_source,
+                        "params": {"field": field}
+                    }
+                }
+                if es_operator == "eq":
+                    es_filters.append({
+                        "term": {
+                            runtime_field_name: int(value)
+                        }
+                    })
+                else:
+                    es_filters.append({
+                        "range": {
+                            runtime_field_name: {
+                                es_operator: int(value)
+                            }
+                        }
+                    })
                 
-        return es_filters
+        return es_filters, runtime_mappings
 
     @staticmethod
     def _get_element_search_query(concept,
@@ -986,7 +1017,9 @@ class Search:
                 .setdefault("post_filter", {}) \
                 .setdefault("bool", {}) \
                 .setdefault("filter", [])
-            post_filter.extend(Search._convert_filters_to_es(filters))
+            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
+            post_filter.extend(es_filters)
+            es_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
 
         if aggs:
             es_query["aggs"] = {}
@@ -1060,7 +1093,9 @@ class Search:
                 .setdefault("post_filter", {}) \
                 .setdefault("bool", {}) \
                 .setdefault("filter", [])
-            post_filter.extend(Search._convert_filters_to_es(filters))
+            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
+            post_filter.extend(es_filters)
+            search_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
 
         if aggs:
             search_query["aggs"] = {}
@@ -1187,7 +1222,9 @@ class Search:
                 .setdefault("post_filter", {}) \
                 .setdefault("bool", {}) \
                 .setdefault("filter", [])
-            post_filter.extend(Search._convert_filters_to_es(filters))
+            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
+            post_filter.extend(es_filters)
+            search_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
             
         if aggs:
             search_query["aggs"] = {}

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -122,7 +122,12 @@ class Search:
         return data_type_list
 
     @staticmethod
-    def _get_concepts_query(query, fuzziness=1, prefix_length=3):
+    def _get_concepts_query(query,
+                            fuzziness=1,
+                            prefix_length=3,
+                            filters=None,
+                            aggs=None,
+                            aggregate_size_limit=None):
         "Static data structure populator, pulled for easier testing"
         query_object = {
             "query": {
@@ -229,6 +234,25 @@ class Search:
                 }
             }
         }
+
+        if filters:
+            post_filter = query_object \
+                .setdefault("post_filter", {}) \
+                .setdefault("bool", {}) \
+                .setdefault("filter", [])
+            post_filter.extend(Search._convert_filters_to_es(filters))
+
+        if aggs:
+            query_object["aggs"] = {}
+            for field, size_limit in aggs.items():
+                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
+                query_object["aggs"][field] = {
+                    "terms": {
+                        "field": field,
+                        "size": size
+                    }
+                }
+
         return query_object
 
     def is_simple_search_query(self, query):
@@ -236,7 +260,7 @@ class Search:
             return False
         return "*" in query or "\"" in query or "+" in query or "-" in query
 
-    async def search_concepts(self, query, offset=0, size=None, concept_types=None, filters=None, **kwargs):
+    async def search_concepts(self, query, offset=0, size=None, concept_types=None, **kwargs):
         """
         Changed to a long boolean match query to optimize search results
         """
@@ -325,45 +349,71 @@ class Search:
         return self._make_result(data_type, search_result_hits, total_items, True)
 
     async def search_elements(self,
-                                  index_name,
-                                  concept="",
-                                  query="",
-                                  parent_ids=None,
-                                  element_ids=None,
-                                  filters=None,
-                                  aggs=None,
-                                  size=None,
-                                  offset=0,
-                                  fuzziness=1,
-                                  prefix_length=3):
+                              index_name,
+                              concept="",
+                              query="",
+                              parent_ids=None,
+                              element_ids=None,
+                              filters=None,
+                              aggs=None,
+                              size=None,
+                              offset=0,
+                              fuzziness=1,
+                              prefix_length=3,
+                              explain=False):
+        is_concepts_search = index_name == self._cfg.concepts_index_name
+        is_simple_search = self.is_simple_search_query(query)
 
-        if self.is_simple_search_query(query):
-            es_query = self._get_element_simple_search_query(concept=concept,
-                                                             query=query,
-                                                             parent_ids=parent_ids,
-                                                             element_ids=element_ids,
-                                                             filters=filters,
-                                                             aggs=aggs,
-                                                             aggregate_size_limit=self._cfg.aggregate_size_limit,
-                                                             new_model=True)
+        if is_concepts_search:
+            if is_simple_search:
+                es_query = self.get_simple_concept_search_query(
+                    query=query,
+                    filters=filters,
+                    aggs=aggs,
+                    aggregate_size_limit=self._cfg.aggregate_size_limit
+                )
+            else:
+                es_query = self._get_concepts_query(
+                    query=query,
+                    fuzziness=fuzziness,
+                    prefix_length=prefix_length,
+                    filters=filters,
+                    aggs=aggs,
+                    aggregate_size_limit=self._cfg.aggregate_size_limit
+                )
         else:
-            es_query = self._get_element_search_query(concept=concept,
-                                                      parent_ids=parent_ids,
-                                                      element_ids=element_ids,
-                                                      filters=filters,
-                                                      aggs=aggs,
-                                                      aggregate_size_limit=self._cfg.aggregate_size_limit,
-                                                      fuzziness=fuzziness,
-                                                      prefix_length=prefix_length,
-                                                      query=query,
-                                                      new_model=True
-                                                      )
+            if is_simple_search:
+                es_query = self._get_element_simple_search_query(
+                    concept=concept,
+                    query=query,
+                    parent_ids=parent_ids,
+                    element_ids=element_ids,
+                    filters=filters,
+                    aggs=aggs,
+                    aggregate_size_limit=self._cfg.aggregate_size_limit,
+                    new_model=True
+                )
+            else:
+                es_query = self._get_element_search_query(
+                    concept=concept,
+                    parent_ids=parent_ids,
+                    element_ids=element_ids,
+                    filters=filters,
+                    aggs=aggs,
+                    aggregate_size_limit=self._cfg.aggregate_size_limit,
+                    fuzziness=fuzziness,
+                    prefix_length=prefix_length,
+                    query=query,
+                    new_model=True
+                )
 
         search_results = await self.es.search(
             index=index_name,
             body=es_query,
             filter_path=['hits.hits._id', 'hits.hits._type',
-                         'hits.hits._source', 'hits.hits._score', 'hits.total', 'aggregations'],
+                         'hits.hits._source', 'hits.hits._score', 'hits.total',
+                         'hits.hits._explanation', 'aggregations'],
+            explain=explain,
             from_=offset,
             size=size or self._cfg.default_page_size
         )
@@ -738,8 +788,6 @@ class Search:
                 es_filters.append({"terms": { field: val }})
             elif operator in ["gt", "gte", "lt", "lte"]:
                 es_filters.append({"range": { field: { operator: value } }})
-            elif operator == "contains":
-                es_filters.append({"wildcard": { field: f"*{value}*" }})
             elif operator == "exists":
                 es_filters.append({"exists": { "field": field }})
             elif operator == "missing":
@@ -955,7 +1003,7 @@ class Search:
         return es_query
 
     @staticmethod
-    def get_simple_concept_search_query(query):
+    def get_simple_concept_search_query(query, filters=None, aggs=None, aggregate_size_limit=None):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
         More info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html."""
         simple_query_string_search = {
@@ -1006,6 +1054,25 @@ class Search:
                 }
             }
         }
+
+        if filters:
+            post_filter = search_query \
+                .setdefault("post_filter", {}) \
+                .setdefault("bool", {}) \
+                .setdefault("filter", [])
+            post_filter.extend(Search._convert_filters_to_es(filters))
+
+        if aggs:
+            search_query["aggs"] = {}
+            for field, size_limit in aggs.items():
+                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
+                search_query["aggs"][field] = {
+                    "terms": {
+                        "field": field,
+                        "size": size
+                    }
+                }
+
         return search_query
 
     @staticmethod

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -748,6 +748,21 @@ class Search:
                         {"exists": {"field": field}}
                     ]}
                 })
+            elif operator.startswith("size"):
+                op_map = {
+                    "size_eq": "==",
+                    "size_gt": ">",
+                    "size_gte": ">=",
+                    "size_lt": "<",
+                    "size_lte": "<="
+                }
+                symbol = op_map[operator]
+                es_filters.append({"script": {
+                    "script": {
+                        "source": f"doc['{ field }'].size() { symbol } params.val",
+                        "params": { "val": int(value) }
+                    }
+                }})
                 
         return es_filters
 
@@ -1159,7 +1174,7 @@ class Search:
 
     def remove_hits_from_results(self, search_results):
         search_result_hits = []
-        if "hits" in search_results:
+        if "hits" in search_results and "hits" in search_results["hits"]:
             search_result_hits = search_results['hits']['hits']
         return search_result_hits
 

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -409,20 +409,16 @@ class Search:
                     new_model=True
                 )
 
-        try:
-            search_results = await self.es.search(
-                index=index_name,
-                body=es_query,
-                filter_path=['hits.hits._id', 'hits.hits._type',
-                            'hits.hits._source', 'hits.hits._score', 'hits.total',
-                            'hits.hits._explanation', 'aggregations'],
-                explain=explain,
-                from_=offset,
-                size=size or self._cfg.default_page_size
-            )
-        except Exception as e:
-            print(e.body)
-            raise e
+        search_results = await self.es.search(
+            index=index_name,
+            body=es_query,
+            filter_path=['hits.hits._id', 'hits.hits._type',
+                        'hits.hits._source', 'hits.hits._score', 'hits.total',
+                        'hits.hits._explanation', 'aggregations'],
+            explain=explain,
+            from_=offset,
+            size=size or self._cfg.default_page_size
+        )
 
         total_items = search_results["hits"]["total"]["value"]
         search_result_hits = self.remove_hits_from_results(search_results)

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -283,8 +283,9 @@ async def get_concepts(search_query: SearchElementQuery):
     Parameters:
     - **query**: Text to get related concepts for. To use a full string in search, encloset text in \"\".
     - **concept_types**: Optional list of concept types to return. Acceptable values can be `disease`, `phenotypic feature`, `drug`, `biological process`, `anatomical entity` etc.
-    - **filters**: List of attribute filters to execute the search using.
-    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
+    - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
+      - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -345,8 +346,9 @@ async def get_variables(search_query: SearchElementQuery):
     - **parent_ids**: List of ids (ex. Study IDs, CDE IDs, CRF IDs) to get variables from.
     - **element_ids**: List of ids for variables/cdes to be fetched. If `query` is not empty, only related variables will be returned.
     - **concept**: 
-    - **filters**: List of attribute filters to execute the search using.
-    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
+    - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
+      - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -401,8 +403,9 @@ async def get_studies(search_query: SearchElementQuery):
     - **parent_ids**: List of ids to get studies from. (** Parents are empty for studies for now)
     - **element_ids**: List of study ids be fetched. If `query` is not empty, only related studies to the query string will be returned.
     - **concept**: 
-    - **filters**: List of attribute filters to execute the search using.
-    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
+    - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
+      - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -461,8 +464,9 @@ async def get_cdes(search_query: SearchElementQuery):
     - **parent_ids**: List of study IDs which use this CDE/CRF.
     - **element_ids**: List of study ids be fetched. If `query` is not empty, only related CDEs to the query string will be returned.
     - **concept**: 
-    - **filters**: List of attribute filters to execute the search using.
-    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
+    - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
+      - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -359,7 +359,7 @@ async def get_variables(search_query: SearchElementQuery):
     - **metadata**: dictionary with variable information like permissible values, min-max, pattern, etc.
 
     """
-    elastic_results, total_count = await search.search_elements(
+    elastic_results, total_count, aggregations = await search.search_elements(
         config.variables_index_name,
         **search_query.dict()
     )
@@ -376,7 +376,8 @@ async def get_variables(search_query: SearchElementQuery):
             "offset": search_query.offset,
             "size": search_query.size,
         },
-        "results": results
+        "results": results,
+        "aggregations": aggregations
     }
     return res
 
@@ -416,7 +417,7 @@ async def get_studies(search_query: SearchElementQuery):
         * **Investigator/s**: List of PIs for the study.
 
     """
-    result, total_count = await search.search_elements(
+    result, total_count, aggregations = await search.search_elements(
         config.studies_index_name,
         **search_query.model_dump()
     )
@@ -435,6 +436,7 @@ async def get_studies(search_query: SearchElementQuery):
             "size": len(studies)
         },
         "results": studies,
+        "aggregations": aggregations
     }
 
 
@@ -470,7 +472,7 @@ async def get_cdes(search_query: SearchElementQuery):
         * **URLs**: List of URLs pointing to downloadable CRF forms.
 
     """
-    elastic_results, total_count = await search.search_elements(
+    elastic_results, total_count, aggregations = await search.search_elements(
         config.sections_index_name,
         **search_query.model_dump()
     )
@@ -486,7 +488,8 @@ async def get_cdes(search_query: SearchElementQuery):
             "offset": search_query.offset,
             "size": search_query.size,
         },
-        "results": results
+        "results": results,
+        "aggregations": aggregations
     }
     return res
 

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -276,7 +276,7 @@ async def search_study(study_id: Optional[str] = None, study_name: Optional[str]
 
 
 @APP.post('/concepts', tags=['v2.0'], response_model=ConceptsAPIResponse)
-async def get_concepts(search_query: SearchConceptQuery):
+async def get_concepts(search_query: SearchElementQuery):
     """
     Search for concepts that are related to the search query passed in `query`
 
@@ -304,15 +304,17 @@ async def get_concepts(search_query: SearchConceptQuery):
     - **offset**
     - **size**
     """
-    concepts, total_count, concept_types = await search.search_concepts(**search_query.model_dump(exclude={"index"}))
-    concepts_wo_hits = search.remove_hits_from_results(concepts)
+    concepts, total_count, aggregations = await search.search_elements(
+        config.concepts_index_name,
+        **search_query.model_dump(),
+        explain=True
+    )
     res_concepts = []
-    if concepts_wo_hits:
-        for concept in concepts_wo_hits:
-            item = concept["_source"]
-            item["score"] = concept["_score"]
-            item["explanation"] = concept["_explanation"]
-            res_concepts.append(item)
+    for concept in concepts:
+        item = concept["_source"]
+        item["score"] = concept["_score"]
+        item["explanation"] = concept["_explanation"]
+        res_concepts.append(item)
 
     res = {
         "metadata": {
@@ -321,7 +323,7 @@ async def get_concepts(search_query: SearchConceptQuery):
             "size": search_query.size,
         },
         "results": res_concepts,
-        "concept_types": concept_types
+        "aggregations": aggregations
     }
     return res
 

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -341,6 +341,7 @@ async def get_variables(search_query: SearchElementQuery):
     - **parent_ids**: List of ids (ex. Study IDs, CDE IDs, CRF IDs) to get variables from.
     - **element_ids**: List of ids for variables/cdes to be fetched. If `query` is not empty, only related variables will be returned.
     - **concept**: 
+    - **filters**: List of attribute filters to execute the search using.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -283,6 +283,8 @@ async def get_concepts(search_query: SearchElementQuery):
     Parameters:
     - **query**: Text to get related concepts for. To use a full string in search, encloset text in \"\".
     - **concept_types**: Optional list of concept types to return. Acceptable values can be `disease`, `phenotypic feature`, `drug`, `biological process`, `anatomical entity` etc.
+    - **filters**: List of attribute filters to execute the search using.
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -344,6 +346,7 @@ async def get_variables(search_query: SearchElementQuery):
     - **element_ids**: List of ids for variables/cdes to be fetched. If `query` is not empty, only related variables will be returned.
     - **concept**: 
     - **filters**: List of attribute filters to execute the search using.
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -398,6 +401,8 @@ async def get_studies(search_query: SearchElementQuery):
     - **parent_ids**: List of ids to get studies from. (** Parents are empty for studies for now)
     - **element_ids**: List of study ids be fetched. If `query` is not empty, only related studies to the query string will be returned.
     - **concept**: 
+    - **filters**: List of attribute filters to execute the search using.
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -456,6 +461,8 @@ async def get_cdes(search_query: SearchElementQuery):
     - **parent_ids**: List of study IDs which use this CDE/CRF.
     - **element_ids**: List of study ids be fetched. If `query` is not empty, only related CDEs to the query string will be returned.
     - **concept**: 
+    - **filters**: List of attribute filters to execute the search using.
+    - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. 
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 


### PR DESCRIPTION
- Adds arbitrary property filtering for DugElement fields on search endpoints
- Adds arbitrary property aggregation for DugElement fields on search endpoints
- Updates `/concepts` endpoint to utilize `search_elements` method.
  - Removes `concept_types` request/response fields; superseded by new `aggs` param.
- Remove `_count` call in `search_elements` in favor of `hits.total`