### PR TITLE
Adding a section list to DugStudy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: "3.0"
 
 #################################################################################
 ##
@@ -15,7 +15,6 @@ version: '3.0'
 ##
 #################################################################################
 services:
-
   #################################################################################
   ##
   ## The OpenAPI endpoint for search. This is the only service to be
@@ -40,9 +39,19 @@ services:
       REDIS_PASSWORD: "$REDIS_PASSWORD"
       FLASK_ENV: "development"
       PYTHONUNBUFFERED: "TRUE"
-    entrypoint: [ "uvicorn",
-                     "--host", "0.0.0.0" , "--port" , "$API_PORT",
-                     "--log-level=debug",  "--reload-dir", "/home/dug/dug/",  "--reload", "dug.server:APP" ]
+    entrypoint:
+      [
+        "uvicorn",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "$API_PORT",
+        "--log-level=debug",
+        "--reload-dir",
+        "/home/dug/dug/",
+        "--reload",
+        "dug.server:APP",
+      ]
     volumes:
       - ./src:/home/dug/dug/
     ports:
@@ -54,7 +63,7 @@ services:
   ##
   #################################################################################
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.3
     networks:
       - dug-network
     environment:
@@ -64,8 +73,8 @@ services:
     volumes:
       - $DATA_DIR/elastic:/usr/share/elasticsearch/data
     ports:
-      - '9200:9200'
-      - '9300:9300'
+      - "9200:9200"
+      - "9300:9300"
 
   #################################################################################
   ##
@@ -74,7 +83,7 @@ services:
   ##
   #################################################################################
   redis:
-    image: 'redis/redis-stack:6.2.4-v2'
+    image: "redis/redis-stack:6.2.4-v2"
     networks:
       - dug-network
     environment:
@@ -83,10 +92,8 @@ services:
     volumes:
       - $DATA_DIR/redis:/data
     ports:
-      - '6379:6379'
-
+      - "6379:6379"
 
 networks:
   dug-network:
     driver: bridge
-

--- a/src/dug/core/index.py
+++ b/src/dug/core/index.py
@@ -208,6 +208,8 @@ class Index:
                     'publications': {"type": "text", "analyzer": "std_with_stopwords"},
                     'variable_list': {"type": "text", "analyzer": "std_with_stopwords",
                                       "fields": {"keyword": {"type": "keyword"}}},
+                    'section_list': {"type": "text", "analyzer": "std_with_stopwords",
+                                      "fields": {"keyword": {"type": "keyword"}}},
                     'abstract': {"type": "text", "analyzer": "std_with_stopwords"},
                     "metadata": {
                         "type": "object",

--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -169,6 +169,7 @@ class DugStudy(DugElement):
     type:Literal["study"]=STUDY_TYPE
     publications:List[str] = Field(default_factory=list)
     variable_list:List[str] = Field(default_factory=list)
+    section_list:List[str] = Field(default_factory=list)
     abstract:str=''
 
     def get_searchable_dict(self):
@@ -177,6 +178,7 @@ class DugStudy(DugElement):
         es_study = {**es_elem, 
                     'publications': self.publications,
                     'variable_list': self.variable_list,
+                    'section_list': self.section_list,
                     'abstract': self.abstract
                    }
         return es_study

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -420,11 +420,14 @@ async def get_studies(search_query: SearchElementQuery):
     - **parents**: List of parent IDs (to be used in future)
     - **publications**: List of publications
     - **variable_list**: List of varible IDs belonging to the study.
+    - **section_list**: List of IDs for sections/standardized questionnaires/CRFs used by this study.
     - **metadata**: dictionary with study information. 
         * **Project Start Date**
         * **Project End Date**
         * **Institution**
         * **Investigator/s**: List of PIs for the study.
+        * **Data Available**: Indicator of study data availability.
+        * **Data Package Links**: List of links to the data packages.
 
     """
     result, total_count, aggregations = await search.search_elements(

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -198,6 +198,7 @@ def test_dug_study_searchable_dict():
         'programs': [],
         'publications': [],
         'variable_list': [],
+        'section_list': [],
         'abstract': study_abstract
     }
 


### PR DESCRIPTION
This PR adds a list of section/questionnaire/instrument/CRF/CDE IDs to the DugStudy. Immediately this will help with filtering on the HEAL frontend. In long term, this list can held standardized and non-standardized forms, with the hope of having a better hierarchical representation, and hence search for data collected by a study. 