### PR TITLE
Allow for disabling redis caching for HTTP requests (for testing)

### DIFF
--- a/src/dug/config.py
+++ b/src/dug/config.py
@@ -23,6 +23,7 @@ class Config:
     elastic_ca_verify: bool = True
     max_ids_limit = 10000
 
+    use_redis_cache: bool = True
     redis_host: str = "redis"
     redis_port: int = 6379
 

--- a/src/dug/core/factory.py
+++ b/src/dug/core/factory.py
@@ -35,11 +35,15 @@ class DugFactory:
             'password': self.config.redis_password,
         }
 
-        return CachedSession(
-            cache_name='annotator',
-            backend='redis',
-            connection=redis.StrictRedis(**redis_config)
-        )
+        if self.config.use_redis_cache:
+            return CachedSession(
+                cache_name='annotator',
+                backend='redis',
+                connection=redis.StrictRedis(**redis_config)
+            )
+        else:
+            return CachedSession(
+                cache_name='annotator')
 
     def build_crawler(self, target, parser: Parser, annotator: Annotator, program_name: str, tranql_source=None) -> Crawler:
         crawler = Crawler(


### PR DESCRIPTION
Command line testing makes DAG changes much easier to test, but having the redis HTTP request caching in place makes that much more difficult. This creates a config option that disables that caching, but it's disabled by default.