### PR TITLE
Adding tags and correcting index name retrieval for elastic index

### DIFF
--- a/src/dug/core/annotators/_base.py
+++ b/src/dug/core/annotators/_base.py
@@ -157,7 +157,7 @@ class DefaultNormalizer():
         preferred_id = normalization.get("id", {})
         equivalent_identifiers = normalization.get("equivalent_identifiers", [])
         biolink_type = normalization.get("type", [])
-        description = normalization.get("description", "")
+        # description = normalization.get("description", "")
         # Return none if there isn't actually a preferred id
         if "identifier" not in preferred_id:
             logger.debug(f"ERROR: normalize({curie})=>({preferred_id}). No identifier?")
@@ -166,7 +166,7 @@ class DefaultNormalizer():
         logger.debug(f"Preferred id: {preferred_id}")
         identifier.id = preferred_id.get("identifier", "")
         identifier.label = preferred_id.get("label", "")
-        identifier.description = description
+        identifier.description = preferred_id.get("description", "")
         identifier.equivalent_identifiers = [
             v["identifier"] for v in equivalent_identifiers
         ]

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -1159,6 +1159,20 @@ class Search:
                                                 **simple_query_string_search,
                                                 "fields": ["search_terms"]
                                             }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "tags",
+                                                "query": {
+                                                    "simple_query_string": {
+                                                        **simple_query_string_search,
+                                                        "fields": [
+                                                            "tags.value.text",
+                                                            "tags.category"
+                                                        ]
+                                                    }
+                                                }
+                                            }
                                         }
                                     ]
                                 }

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -960,6 +960,35 @@ class Search:
                                     "prefix_length": prefix_length
                                 }
                             }
+                        },
+                        {
+                            "nested": {
+                                "path": "tags",
+                                "query": {
+                                    "match_phrase": {
+                                        "tags.value.text": {
+                                            "query": query,
+                                            "boost": 8
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "nested": {
+                                "path": "tags",
+                                "query": {
+                                    "match": {
+                                        "tags.value.text": {
+                                            "query": query,
+                                            "fuzziness": fuzziness,
+                                            "prefix_length": prefix_length,
+                                            "operator": "and",
+                                            "boost": 4
+                                        }
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
@@ -1167,8 +1196,7 @@ class Search:
                                                     "simple_query_string": {
                                                         **simple_query_string_search,
                                                         "fields": [
-                                                            "tags.value.text",
-                                                            "tags.category"
+                                                            "tags.value.text"
                                                         ]
                                                     }
                                                 }

--- a/src/dug/core/index.py
+++ b/src/dug/core/index.py
@@ -394,12 +394,14 @@ class Index:
             optional_terms = results['_source']['optional_terms'] + update_doc['optional_terms']
             parents = results['_source']['parents'] + update_doc['parents']
             programs = results['_source']['programs'] + update_doc['programs']
+            tags = results['_source']['tags'] + update_doc['tags']
             identifiers = results['_source']['identifiers'] + update_doc['identifiers']
             doc = {"doc": {}}
             doc['doc']['search_terms'] = list(set(search_terms))
             doc['doc']['optional_terms'] = list(set(optional_terms))
             doc['doc']['parents'] = list(set(parents))
             doc['doc']['programs'] = list(set(programs))
+            doc['doc']['tags'] = [dict(t) for t in {tuple(sorted(d.items())) for d in tags}]
             doc['doc']['identifiers'] = list(set(identifiers))
             self.update_doc(index=index, doc=doc, doc_id=elem.get_id())
 

--- a/src/dug/core/index.py
+++ b/src/dug/core/index.py
@@ -131,8 +131,23 @@ class Index:
                         "type": "object",
                         "dynamic": True
                     },
-                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
-                                 "fields": {"keyword": {"type": "keyword"}}}
+                    "tags": {
+                        "type": "nested",
+                        "properties": {
+                            "category": {
+                                "type": "keyword",
+                            },
+                            "value": {
+                                "type": "keyword",
+                                "fields": {
+                                    "text": {
+                                        "type": "text",
+                                        "analyzer": "std_with_stopwords"
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -171,8 +186,23 @@ class Index:
                     "metadata": {
                         "type": "flattened"
                     },
-                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
-                                 "fields": {"keyword": {"type": "keyword"}}}
+                    "tags": {
+                        "type": "nested",
+                        "properties": {
+                            "category": {
+                                "type": "keyword",
+                            },
+                            "value": {
+                                "type": "keyword",
+                                "fields": {
+                                    "text": {
+                                        "type": "text",
+                                        "analyzer": "std_with_stopwords"
+                                    }
+                                }
+                            }
+                        }
+                    }
                     # typed as keyword for bucket aggs
                 }
             }
@@ -215,8 +245,23 @@ class Index:
                         "type": "object",
                         "dynamic": True
                     },
-                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
-                                 "fields": {"keyword": {"type": "keyword"}}}
+                    "tags": {
+                        "type": "nested",
+                        "properties": {
+                            "category": {
+                                "type": "keyword",
+                            },
+                            "value": {
+                                "type": "keyword",
+                                "fields": {
+                                    "text": {
+                                        "type": "text",
+                                        "analyzer": "std_with_stopwords"
+                                    }
+                                }
+                            }
+                        }
+                    }
                     # typed as keyword for bucket aggs
                 }
             }
@@ -258,8 +303,23 @@ class Index:
                         "type": "object",
                         "dynamic": True
                     },
-                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
-                                 "fields": {"keyword": {"type": "keyword"}}}
+                    "tags": {
+                        "type": "nested",
+                        "properties": {
+                            "category": {
+                                "type": "keyword",
+                            },
+                            "value": {
+                                "type": "keyword",
+                                "fields": {
+                                    "text": {
+                                        "type": "text",
+                                        "analyzer": "std_with_stopwords"
+                                    }
+                                }
+                            }
+                        }
+                    }
                     # typed as keyword for bucket aggs
                 }
             }

--- a/src/dug/core/index.py
+++ b/src/dug/core/index.py
@@ -12,18 +12,18 @@ logger = logging.getLogger('dug')
 
 
 class Index:
-    def __init__(self, cfg: Config, indices=None):
+    def __init__(self, cfg: Config):
 
-        if indices is None:
-            indices = {'concepts_index':'concepts_index', 
-                       'variables_index':'variables_index', 
-                       'studies_index':'studies_index',
-                       'sections_index':'sections_index',
-                       'kg_index':'kg_index'}
-        
         self._cfg = cfg
         logger.debug(f"******** Connecting to elasticsearch host: {self._cfg.elastic_host} at port: {self._cfg.elastic_port}")
 
+        indices = {
+            'concepts_index': self._cfg.concepts_index_name,
+            'variables_index': self._cfg.variables_index_name,
+            'studies_index': self._cfg.studies_index_name,
+            'sections_index': self._cfg.sections_index_name,
+            'kg_index': self._cfg.kg_index_name
+        }
         self.indices = indices
         self.hosts = [{'host': self._cfg.elastic_host, 'port': self._cfg.elastic_port, 'scheme': self._cfg.elastic_scheme}]
 
@@ -130,7 +130,9 @@ class Index:
                     "metadata": {
                         "type": "object",
                         "dynamic": True
-                    }
+                    },
+                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
+                                 "fields": {"keyword": {"type": "keyword"}}}
                 }
             }
         }
@@ -167,10 +169,10 @@ class Index:
                     "data_type": {"type": "text", "analyzer": "std_with_stopwords",
                                   "fields": {"keyword": {"type": "keyword"}}},
                     "metadata": {
-                        "type": "object",
-                        "dynamic": True,
-                        "numeric_detection": False
-                    }
+                        "type": "flattened"
+                    },
+                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
+                                 "fields": {"keyword": {"type": "keyword"}}}
                     # typed as keyword for bucket aggs
                 }
             }
@@ -212,7 +214,9 @@ class Index:
                     "metadata": {
                         "type": "object",
                         "dynamic": True
-                    }
+                    },
+                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
+                                 "fields": {"keyword": {"type": "keyword"}}}
                     # typed as keyword for bucket aggs
                 }
             }
@@ -253,7 +257,9 @@ class Index:
                     "metadata": {
                         "type": "object",
                         "dynamic": True
-                    }
+                    },
+                    "tags": {"type": "text", "analyzer": "std_with_stopwords",
+                                 "fields": {"keyword": {"type": "keyword"}}}
                     # typed as keyword for bucket aggs
                 }
             }

--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -31,6 +31,7 @@ class DugElement(BaseModel):
     search_terms: List[str] = Field(default_factory=list)
     optional_terms: List[str] = Field(default_factory=list)
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
     
     @computed_field
     @property

--- a/src/dug/core/parsers/_base.py
+++ b/src/dug/core/parsers/_base.py
@@ -31,7 +31,7 @@ class DugElement(BaseModel):
     search_terms: List[str] = Field(default_factory=list)
     optional_terms: List[str] = Field(default_factory=list)
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    tags: List[str] = Field(default_factory=list)
+    tags: List[Dict[str, str]] = Field(default_factory=list)
     
     @computed_field
     @property
@@ -71,6 +71,7 @@ class DugElement(BaseModel):
             'parents': self.parents,
             'programs': self.programs,
             'identifiers': (list(self.concepts.keys()) if self.concepts else []),
+            'tags': self.tags
         }
         return es_elem
 
@@ -78,7 +79,6 @@ class DugElement(BaseModel):
         response = self.get_searchable_dict()
         things_to_hide = ['search_terms', 'optional_terms',]
         return {x: response[x] for x in response if x not in things_to_hide}
-
 
     def get_id(self) -> str:
         return f'{self.id}'
@@ -103,6 +103,9 @@ class DugElement(BaseModel):
     def clean(self):
         self.search_terms = sorted(list(set(self.search_terms)))
         self.optional_terms = sorted(list(set(self.optional_terms)))
+    
+    def add_tag(self, category, value):
+        self.tags.append({"category": category, "value":value})
 
     def __str__(self):
         return json.dumps(self.jsonable(), indent=2, default=utils.complex_handler)

--- a/tests/integration/test_parsers.py
+++ b/tests/integration/test_parsers.py
@@ -161,3 +161,4 @@ def test_heal_study_ddm2_parser():
     assert(len(studies) == 1)
     variables = [k for k in elements if k.type == 'variable']
     assert(len(variables) > 0)
+    assert(studies[0].tags == [{"category":"Research Network", "value":"JCOIN"}])

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -79,6 +79,7 @@ def test_dug_element_searchable_dict():
         description=elem_desc, 
         type=elem_type,
     )
+    element.add_tag("data type", "integer")
     searchable = element.get_searchable_dict()
     assert searchable == {
         'id': elem_id,
@@ -92,7 +93,7 @@ def test_dug_element_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
-        'tags': []
+        'tags': [{"category": "data type", "value":"integer"}]
     }
 
 
@@ -132,8 +133,9 @@ def test_dug_variable_searchable_dict():
         name=variable_name, 
         description=variable_desc, 
         type=elem_type,
-        data_type=data_type
+        data_type=data_type,
     )
+    variable.add_tag("network", "dummy_network")
     searchable = variable.get_searchable_dict()
     assert searchable == {
         'id': variable_id,
@@ -147,7 +149,7 @@ def test_dug_variable_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
-        'tags': [],
+        'tags': [{"category": "network", "value":"dummy_network"}],
         'data_type': data_type,
         'is_cde': False
     }

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -43,7 +43,8 @@ def test_dug_concept_searchable_dict():
         'identifiers': [],
         'metadata': {},
         'parents': [],
-        'programs': []
+        'programs': [],
+        'tags': []
     }
 
 
@@ -91,6 +92,7 @@ def test_dug_element_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
+        'tags': []
     }
 
 
@@ -145,6 +147,7 @@ def test_dug_variable_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
+        'tags': [],
         'data_type': data_type,
         'is_cde': False
     }
@@ -196,6 +199,7 @@ def test_dug_study_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
+        'tags': [],
         'publications': [],
         'variable_list': [],
         'abstract': study_abstract
@@ -248,6 +252,7 @@ def test_dug_section_searchable_dict():
         'metadata': {},
         'parents': [],
         'programs': [],
+        'tags': [],
         'variable_list': [],
         'is_crf': is_crf
     }


### PR DESCRIPTION
Addings tags to "DugElement"
Resolved a bug where Indexer was pulling the wrong index names at startup resulting in index mapping mismatch when index names were not default.