### PR TITLE
Change Trivy action to version 0.33.1

### DIFF
--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -50,7 +50,7 @@ jobs:
 
     # We will not be concerned with Medium and Low vulnerabilities
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.33.1
       with:
         image-ref: '${{ github.repository }}:vuln-test'
         format: 'sarif'


### PR DESCRIPTION
Updated Trivy action version to 0.33.1 for vulnerability scanning. Trivy is compromised so we are using an older version.