### PR TITLE
Update dug-data-model dependency to use Git URL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 python_requires = >=3.10
 include_package_data = true
 install_requires =
-    git+https://github.com/helxplatform/dug-data-model.git@main
+    dug-data-model @ git+https://github.com/helxplatform/dug-data-model.git@main
     elasticsearch==8.5.2
     pluggy
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 python_requires = >=3.10
 include_package_data = true
 install_requires =
-    dug-data-model
+    git+https://github.com/helxplatform/dug-data-model.git@main
     elasticsearch==8.5.2
     pluggy
     requests


### PR DESCRIPTION
fix: ddm2 library is not on pip