### PR TITLE
Add ES-field based sorting options to v2 search endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ canonical reference. The current endpoints, grouped by data model type (see [The
 
 | Endpoint              | Method | Description                                                                 |
 | ---------------------- | ------ | ---------------------------------------------------------------------------- |
-| `/concepts`            | POST   | Search `DugConcept`s related to a query, with filters/aggregations.         |
+| `/concepts`            | POST   | Search `DugConcept`s related to a query, with filters/aggregations/sorting. |
 | `/studies`             | POST   | Search `DugStudy` entities related to a query, or by `parent_ids`/`element_ids`. |
 | `/cdes`                | POST   | Search `DugSection` (CDE set / CRF) entities.                               |
 | `/variables`           | POST   | Search `DugVariable`/CDE entities, optionally scoped to `parent_ids`.       |
@@ -285,6 +285,28 @@ canonical reference. The current endpoints, grouped by data model type (see [The
 The `/concepts`, `/studies`, `/cdes`, and `/variables` endpoints (tagged `v2.0` in `/docs`) are the current,
 data-model-backed way to query Dug; the `/search*` and `/dump_concepts`/`/agg_data_types` endpoints predate the Dug
 Data Model and are kept for backward compatibility.
+
+### Filtering, aggregating, and sorting
+
+The four `v2.0` endpoints all accept `filters`, `aggs`, and `sort`, each of which names raw Elasticsearch fields.
+Field names are passed through to Elasticsearch rather than checked against an allowlist, so the index mappings in
+`src/dug/core/index.py` are the source of truth for what's available. A field Elasticsearch rejects comes back as a
+`400` naming the reason, not a `500`.
+
+Results are ordered by relevance score unless `sort` is given. `sort` is an ordered list — later keys only break ties
+in the earlier ones — and relevance score plus a stable `id.keyword` tiebreaker are always appended, so paging stays
+deterministic. Documents missing the sort field go last in both directions.
+
+```shell
+curl -X POST http://localhost:5551/studies -H 'content-type: application/json' -d '{
+  "query": "opioid",
+  "sort": [{"field": "metadata.Project End Date", "order": "desc"}]
+}'
+```
+
+The usual pitfall is that `text` fields are not sortable. Sort on a `keyword` subfield (`data_type.keyword`,
+`parents.keyword`) instead. Note that `name` and `description` are mapped as `text` with no such subfield in any
+index, so they cannot be sorted on today.
 
 ## Development
 

--- a/src/dug/api_models/request_models.py
+++ b/src/dug/api_models/request_models.py
@@ -46,6 +46,40 @@ class FilterCriterion(BaseModel):
     operator: FilterOperator = Field("eq", description="Comparison operator")
     value: Optional[Union[str, int, float, bool, List[Any]]] = Field(default=None, description="The value to filter against")
 
+SortOrder = Literal["asc", "desc"]
+SortMode = Literal["min", "max", "sum", "avg", "median"]
+MissingPlacement = Literal["_first", "_last"]
+
+# Guardrail on request complexity, in the spirit of Config.aggregate_size_limit
+MAX_SORT_FIELDS = 5
+
+class SortCriterion(BaseModel):
+    field: str = Field(..., description=(
+        "Elasticsearch field to sort on (e.g. 'metadata.Project End Date'). Must be a "
+        "doc_values field (keyword/date/numeric/boolean); 'text' fields are not sortable, "
+        "use their '.keyword' subfield."
+    ))
+    order: SortOrder = Field("asc", description="Sort direction")
+    mode: Optional[SortMode] = Field(default=None, description=(
+        "Which value to sort on for multi-valued fields (parents, programs, variable_list, "
+        "tags...). Defaults to Elasticsearch behavior: min for asc, max for desc."
+    ))
+    missing: Optional[MissingPlacement] = Field(default=None, description=(
+        "Where documents lacking the field are placed. Defaults to '_last' in both directions."
+    ))
+
+    @field_validator("field")
+    @classmethod
+    def validate_field(cls, v):
+        v = (v or "").strip()
+        if not v:
+            raise ValueError("sort field must not be empty")
+        # _score and _doc are the only elasticsearch pseudo-fields that can be sorted
+        # on; letting other underscore names through just yields a confusing ES error.
+        if v.startswith("_") and v not in ("_score", "_doc"):
+            raise ValueError(f"'{v}' is not a sortable field")
+        return v
+
 class SearchElementQuery(BaseModel):
     query: str = None
     simple_search: bool = False
@@ -55,6 +89,10 @@ class SearchElementQuery(BaseModel):
 
     aggs: Optional[Dict[str, int]] = Field(default=None, description="Specify fields to aggregate against and the bucket limit")
     filters: Optional[List[FilterCriterion]] = Field(default_factory=list)
+    sort: Optional[List[SortCriterion]] = Field(default_factory=list, description=(
+        "Ordered list of sort keys, applied before relevance score. Note that fields are "
+        "ES fields, so subfields like `.keyword` may be required."
+    ))
 
     size: Optional[int] = 100
     offset: Optional[int] = 0
@@ -65,6 +103,13 @@ class SearchElementQuery(BaseModel):
         if v is None:
             return v
         return [item for item in v if item not in ("", None)]
+
+    @field_validator("sort")
+    @classmethod
+    def cap_sort_keys(cls, v):
+        if v and len(v) > MAX_SORT_FIELDS:
+            raise ValueError(f"at most {MAX_SORT_FIELDS} sort keys are supported")
+        return v
 
 class VariableIds(BaseModel):
     """

--- a/src/dug/core/async_search.py
+++ b/src/dug/core/async_search.py
@@ -1,6 +1,6 @@
 """Implements search methods using async interfaces"""
 import logging
-from elasticsearch import AsyncElasticsearch, helpers
+from elasticsearch import AsyncElasticsearch, ApiError, helpers
 from elasticsearch.helpers import async_scan
 import ssl, json
 from dug.config import Config
@@ -24,6 +24,13 @@ class Search:
          * disease->study
          * disease->phenotype->study
     """
+
+    # Fields mapped as `nested` in index.py::init_indices. Sorting on a subfield of a
+    # nested field requires an explicit nested path or elasticsearch rejects the query.
+    NESTED_SORT_PATHS = ("tags",)
+
+    # Present in every v2.0 index mapping, so always safe as a stable tiebreaker.
+    DEFAULT_SORT_TIEBREAKER = "id.keyword"
 
     def __init__(self, cfg: Config):
 
@@ -127,6 +134,7 @@ class Search:
                             prefix_length=3,
                             filters=None,
                             aggs=None,
+                            sort=None,
                             aggregate_size_limit=None):
         "Static data structure populator, pulled for easier testing"
         query_object = {
@@ -235,27 +243,9 @@ class Search:
             }
         }
 
-        if filters:
-            post_filter = query_object \
-                .setdefault("post_filter", {}) \
-                .setdefault("bool", {}) \
-                .setdefault("filter", [])
-            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
-            post_filter.extend(es_filters)
-            query_object.setdefault("runtime_mappings", {}).update(es_rt_mappings)
-
-        if aggs:
-            query_object["aggs"] = {}
-            for field, size_limit in aggs.items():
-                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
-                query_object["aggs"][field] = {
-                    "terms": {
-                        "field": field,
-                        "size": size
-                    }
-                }
-
-        return query_object
+        return Search._apply_common_clauses(
+            query_object, filters=filters, aggs=aggs, sort=sort,
+            aggregate_size_limit=aggregate_size_limit)
 
     def is_simple_search_query(self, query):
         if not query:
@@ -359,6 +349,7 @@ class Search:
                               element_ids=None,
                               filters=None,
                               aggs=None,
+                              sort=None,
                               size=None,
                               offset=0,
                               fuzziness=1,
@@ -373,6 +364,7 @@ class Search:
                     query=query,
                     filters=filters,
                     aggs=aggs,
+                    sort=sort,
                     aggregate_size_limit=self._cfg.aggregate_size_limit
                 )
             else:
@@ -382,6 +374,7 @@ class Search:
                     prefix_length=prefix_length,
                     filters=filters,
                     aggs=aggs,
+                    sort=sort,
                     aggregate_size_limit=self._cfg.aggregate_size_limit
                 )
         else:
@@ -393,6 +386,7 @@ class Search:
                     element_ids=element_ids,
                     filters=filters,
                     aggs=aggs,
+                    sort=sort,
                     aggregate_size_limit=self._cfg.aggregate_size_limit,
                     new_model=True
                 )
@@ -403,6 +397,7 @@ class Search:
                     element_ids=element_ids,
                     filters=filters,
                     aggs=aggs,
+                    sort=sort,
                     aggregate_size_limit=self._cfg.aggregate_size_limit,
                     fuzziness=fuzziness,
                     prefix_length=prefix_length,
@@ -410,16 +405,29 @@ class Search:
                     new_model=True
                 )
 
-        search_results = await self.es.search(
-            index=index_name,
-            body=es_query,
-            filter_path=['hits.hits._id', 'hits.hits._type',
-                        'hits.hits._source', 'hits.hits._score', 'hits.total',
-                        'hits.hits._explanation', 'aggregations'],
-            explain=explain,
-            from_=offset,
-            size=size or self._cfg.default_page_size
-        )
+        try:
+            search_results = await self.es.search(
+                index=index_name,
+                body=es_query,
+                filter_path=['hits.hits._id', 'hits.hits._type',
+                            'hits.hits._source', 'hits.hits._score', 'hits.total',
+                            'hits.hits._explanation', 'aggregations'],
+                explain=explain,
+                from_=offset,
+                size=size or self._cfg.default_page_size
+            )
+        except ApiError as err:
+            status = getattr(err, "status_code", None)
+            if status is None or not 400 <= status < 500:
+                raise
+            reason = Search._extract_es_error_reason(err)
+            logger.warning("Elasticsearch rejected query on %s: %s", index_name, reason)
+            raise SearchException(
+                message="Elasticsearch rejected the search request. Check that the "
+                        "fields named in `sort`, `filters`, and `aggs` exist and are "
+                        "sortable/aggregatable (text fields need a '.keyword' subfield).",
+                details=reason,
+            ) from err
 
         total_items = search_results["hits"]["total"]["value"]
         search_result_hits = self.remove_hits_from_results(search_results)
@@ -767,20 +775,39 @@ class Search:
             return program_summary
 
     @staticmethod
+    def _get_attr(obj, key, default=None):
+        """Reads `key` off either a Pydantic model or an already-dumped dict.
+
+        Note that `getattr(obj, key, obj.get(key))` does not work here: Python
+        evaluates the default eagerly, so it raises AttributeError on a model.
+        """
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    @staticmethod
+    def _extract_es_error_reason(err):
+        """Pulls the human-readable reason out of an elasticsearch ApiError."""
+        try:
+            return err.body["error"]["root_cause"][0]["reason"]
+        except (AttributeError, KeyError, IndexError, TypeError):
+            return str(err)
+
+    @staticmethod
     def _convert_filters_to_es(filters):
         """
         Converts a list of FilterCriterion dicts into ElasticSearch DSL dicts.
         """
         if not filters:
             return [], {}
-            
+
         es_filters = []
         runtime_mappings = {}
         for f in filters:
             # Support both Pydantic model and dumped dict format
-            field = getattr(f, "field", f.get("field"))
-            operator = getattr(f, "operator", f.get("operator"))
-            value = getattr(f, "value", f.get("value"))
+            field = Search._get_attr(f, "field")
+            operator = Search._get_attr(f, "operator")
+            value = Search._get_attr(f, "value")
 
             if operator == "eq":
                 es_filters.append({"term": { field: value }})
@@ -846,6 +873,98 @@ class Search:
         return es_filters, runtime_mappings
 
     @staticmethod
+    def _convert_sort_to_es(sort, tiebreaker_field=None):
+        """
+        Converts a list of SortCriterion (models or dumped dicts) into an
+        ElasticSearch `sort` array.
+
+        Relevance score and a stable tiebreaker are always appended as the final
+        keys, so that documents tying on the caller's sort fields stay ranked by
+        relevance and paginated results are deterministic across requests.
+        """
+        if not sort:
+            return []
+
+        tiebreaker_field = tiebreaker_field or Search.DEFAULT_SORT_TIEBREAKER
+        es_sort = []
+        for criterion in sort:
+            field = Search._get_attr(criterion, "field")
+            if not field:
+                continue
+            order = Search._get_attr(criterion, "order") or "asc"
+
+            if field in ("_score", "_doc"):
+                # These are elasticsearch's own pseudo-fields rather than document
+                # fields, so missing/mode/nested don't apply to them.
+                es_sort.append({field: {"order": order}})
+                continue
+
+            clause = {"order": order}
+
+            missing = Search._get_attr(criterion, "missing")
+            # Elasticsearch defaults to _last for asc but _first for desc, which would
+            # put every document *lacking* the field at the top of a descending sort.
+            clause["missing"] = missing if missing is not None else "_last"
+
+            mode = Search._get_attr(criterion, "mode")
+            if mode:
+                clause["mode"] = mode
+
+            root = field.split(".", 1)[0]
+            if root in Search.NESTED_SORT_PATHS:
+                clause["nested"] = {"path": root}
+
+            es_sort.append({field: clause})
+
+        if not es_sort:
+            return []
+
+        fields_used = {next(iter(clause)) for clause in es_sort}
+        if "_score" not in fields_used:
+            es_sort.append({"_score": {"order": "desc"}})
+        if tiebreaker_field not in fields_used:
+            es_sort.append({tiebreaker_field: {"order": "asc"}})
+
+        return es_sort
+
+    @staticmethod
+    def _apply_common_clauses(query_object, filters=None, aggs=None, sort=None,
+                              aggregate_size_limit=None):
+        """
+        Applies the post_filter/runtime_mappings/aggs/sort tail shared by every v2.0
+        query builder. Mutates and returns `query_object`.
+        """
+        if filters:
+            post_filter = query_object \
+                .setdefault("post_filter", {}) \
+                .setdefault("bool", {}) \
+                .setdefault("filter", [])
+            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
+            post_filter.extend(es_filters)
+            query_object.setdefault("runtime_mappings", {}).update(es_rt_mappings)
+
+        if aggs:
+            query_object["aggs"] = {}
+            for field, size_limit in aggs.items():
+                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
+                query_object["aggs"][field] = {
+                    "terms": {
+                        "field": field,
+                        "size": size
+                    }
+                }
+
+        if sort:
+            es_sort = Search._convert_sort_to_es(sort)
+            if es_sort:
+                query_object["sort"] = es_sort
+                # Without this elasticsearch returns a null _score on every hit whenever
+                # a sort is present, which the float-typed response models reject.
+                query_object["track_scores"] = True
+
+        return query_object
+
+    @staticmethod
     def _get_element_search_query(concept,
                                   fuzziness,
                                   prefix_length,
@@ -855,6 +974,7 @@ class Search:
                                   parent_ids=None,
                                   filters=None,
                                   aggs=None,
+                                  sort=None,
                                   aggregate_size_limit=None):
         """Returns ES query for variable search"""
         element_name = "element_name"
@@ -1041,31 +1161,13 @@ class Search:
                     }
                 )
 
-        if filters:
-            post_filter = es_query \
-                .setdefault("post_filter", {}) \
-                .setdefault("bool", {}) \
-                .setdefault("filter", [])
-            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
-            post_filter.extend(es_filters)
-            es_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
-
-        if aggs:
-            es_query["aggs"] = {}
-            for field, size_limit in aggs.items():
-                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
-                es_query["aggs"][field] = {
-                    "terms": {
-                        "field": field,
-                        "size": size
-                    }
-                }
-
-
-        return es_query
+        return Search._apply_common_clauses(
+            es_query, filters=filters, aggs=aggs, sort=sort,
+            aggregate_size_limit=aggregate_size_limit)
 
     @staticmethod
-    def get_simple_concept_search_query(query, filters=None, aggs=None, aggregate_size_limit=None):
+    def get_simple_concept_search_query(query, filters=None, aggs=None, sort=None,
+                                        aggregate_size_limit=None):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
         More info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html."""
         simple_query_string_search = {
@@ -1117,27 +1219,9 @@ class Search:
             }
         }
 
-        if filters:
-            post_filter = search_query \
-                .setdefault("post_filter", {}) \
-                .setdefault("bool", {}) \
-                .setdefault("filter", [])
-            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
-            post_filter.extend(es_filters)
-            search_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
-
-        if aggs:
-            search_query["aggs"] = {}
-            for field, size_limit in aggs.items():
-                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
-                search_query["aggs"][field] = {
-                    "terms": {
-                        "field": field,
-                        "size": size
-                    }
-                }
-
-        return search_query
+        return Search._apply_common_clauses(
+            search_query, filters=filters, aggs=aggs, sort=sort,
+            aggregate_size_limit=aggregate_size_limit)
 
     @staticmethod
     def _get_element_simple_search_query(
@@ -1148,6 +1232,7 @@ class Search:
         element_ids=None,
         filters=None,
         aggs=None,
+        sort=None,
         aggregate_size_limit=None
     ):
         """Returns ES query that allows to use basic operators like AND, OR, NOT...
@@ -1259,28 +1344,9 @@ class Search:
                     }
                 )
 
-        if filters:
-            post_filter = search_query \
-                .setdefault("post_filter", {}) \
-                .setdefault("bool", {}) \
-                .setdefault("filter", [])
-            es_filters, es_rt_mappings = Search._convert_filters_to_es(filters)
-            post_filter.extend(es_filters)
-            search_query.setdefault("runtime_mappings", {}).update(es_rt_mappings)
-            
-        if aggs:
-            search_query["aggs"] = {}
-            for field, size_limit in aggs.items():
-                size = min(size_limit, aggregate_size_limit) if aggregate_size_limit is not None else size_limit
-                search_query["aggs"][field] = {
-                    "terms": {
-                        "field": field,
-                        "size": size
-                    }
-                }
-
-
-        return search_query
+        return Search._apply_common_clauses(
+            search_query, filters=filters, aggs=aggs, sort=sort,
+            aggregate_size_limit=aggregate_size_limit)
 
     async def get_elements_by_ids(self, ids: [str], index_name=""):
         """Returns variables by ids"""

--- a/src/dug/server.py
+++ b/src/dug/server.py
@@ -2,10 +2,11 @@ import logging
 import os
 import uvicorn
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from dug.config import Config
-from dug.core.async_search import Search
+from dug.core.async_search import Search, SearchException
 from typing import Set, Any
 import asyncio
 from contextlib import asynccontextmanager
@@ -38,6 +39,14 @@ APP.add_middleware(
 
 config = Config.from_env()
 search = Search(config)
+
+@APP.exception_handler(SearchException)
+async def handle_search_exception(request: Request, exc: SearchException):
+    """A query elasticsearch refuses is the caller's problem, not a server error."""
+    return JSONResponse(
+        status_code=400,
+        content={"message": exc.message, "details": exc.details, "status": "error"},
+    )
 
 def shutdown_event():
     asyncio.run(search.es.close())
@@ -291,6 +300,12 @@ async def get_concepts(search_query: SearchElementQuery):
     - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
       - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
     - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
+    - **sort**: Ordered list of sort keys, applied ahead of relevance score. Results are sorted by the first key; later keys only break ties, in the order given. Max 5 keys. Each entry takes:
+      - **field**: An ES field. `text` fields are not sortable, so subfields like `.keyword` may be required.
+      - **order**: `asc` or `desc`. Defaults to `asc`.
+      - **mode**: For multi-valued fields, which value to sort on: `min`, `max`, `sum`, `avg`, `median`. Defaults to ES behavior (min for asc, max for desc).
+      - **missing**: Where documents lacking the field go: `_first` or `_last`. Defaults to `_last` in both directions.
+      Relevance score and a stable id tiebreaker are always appended, so paging is deterministic.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -320,7 +335,10 @@ async def get_concepts(search_query: SearchElementQuery):
     res_concepts = []
     for concept in concepts:
         item = concept["_source"]
-        item["score"] = concept["_score"]
+        # A null score is possible whenever a sort is applied, so don't hand it
+        # straight to the float-typed response model.
+        score = concept.get("_score")
+        item["score"] = score if score is not None else 0
         item["explanation"] = concept["_explanation"]
         res_concepts.append(item)
 
@@ -354,6 +372,12 @@ async def get_variables(search_query: SearchElementQuery):
     - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
       - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
     - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
+    - **sort**: Ordered list of sort keys, applied ahead of relevance score. Results are sorted by the first key; later keys only break ties, in the order given. Max 5 keys. Each entry takes:
+      - **field**: An ES field. `text` fields are not sortable, so subfields like `.keyword` may be required.
+      - **order**: `asc` or `desc`. Defaults to `asc`.
+      - **mode**: For multi-valued fields, which value to sort on: `min`, `max`, `sum`, `avg`, `median`. Defaults to ES behavior (min for asc, max for desc).
+      - **missing**: Where documents lacking the field go: `_first` or `_last`. Defaults to `_last` in both directions.
+      Relevance score and a stable id tiebreaker are always appended, so paging is deterministic.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -373,13 +397,14 @@ async def get_variables(search_query: SearchElementQuery):
     """
     elastic_results, total_count, aggregations = await search.search_elements(
         config.variables_index_name,
-        **search_query.dict()
+        **search_query.model_dump()
     )
 
     results = []
     for result in elastic_results:
         item = result["_source"]
-        item["score"] = result["_score"]
+        score = result.get("_score")
+        item["score"] = score if score is not None else 0
         item["explanation"] = result.get("_explanation", {})
         results.append(item)
     res = {
@@ -411,11 +436,19 @@ async def get_studies(search_query: SearchElementQuery):
     - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
       - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
     - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
+    - **sort**: Ordered list of sort keys, applied ahead of relevance score. Results are sorted by the first key; later keys only break ties, in the order given. Max 5 keys. Each entry takes:
+      - **field**: An ES field. `text` fields are not sortable, so subfields like `.keyword` may be required.
+      - **order**: `asc` or `desc`. Defaults to `asc`.
+      - **mode**: For multi-valued fields, which value to sort on: `min`, `max`, `sum`, `avg`, `median`. Defaults to ES behavior (min for asc, max for desc).
+      - **missing**: Where documents lacking the field go: `_first` or `_last`. Defaults to `_last` in both directions.
+      Relevance score and a stable id tiebreaker are always appended, so paging is deterministic.
+      To list the most recently completed studies first:
+      `[{"field": "metadata.Project End Date", "order": "desc"}]`
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
     Returns:
-    
+
     Dict with study list.
     Each study has the following structure:
     - **id**
@@ -475,6 +508,12 @@ async def get_cdes(search_query: SearchElementQuery):
     - **filters**: List of attribute filters to execute the search using. Note that fields are ES fields, so subfields like `.keyword` may be required. Available operators:
       - "eq", "neq", "gt", "gte", "lt", "lte", "in", "exists", "missing", "size_eq", "size_gt", "size_gte", "size_lt", "size_lte"
     - **aggs**: Key-value store of fields to do aggregations on, where key represents the field and value represents the max number of buckets to return. Note that fields are ES fields, so subfields like `.keyword` may be required.
+    - **sort**: Ordered list of sort keys, applied ahead of relevance score. Results are sorted by the first key; later keys only break ties, in the order given. Max 5 keys. Each entry takes:
+      - **field**: An ES field. `text` fields are not sortable, so subfields like `.keyword` may be required.
+      - **order**: `asc` or `desc`. Defaults to `asc`.
+      - **mode**: For multi-valued fields, which value to sort on: `min`, `max`, `sum`, `avg`, `median`. Defaults to ES behavior (min for asc, max for desc).
+      - **missing**: Where documents lacking the field go: `_first` or `_last`. Defaults to `_last` in both directions.
+      Relevance score and a stable id tiebreaker are always appended, so paging is deterministic.
     - **offset**: Offset index used for pagination
     - **size**: Maximum number of items to return in the string
 
@@ -500,7 +539,9 @@ async def get_cdes(search_query: SearchElementQuery):
     results = []
     for result in elastic_results:
         item = result.get("_source")
-        item["score"] = result.get("_score", 0)
+        # .get(..., 0) is not a guard here: the key is present but null when sorting.
+        score = result.get("_score")
+        item["score"] = score if score is not None else 0
         item["explanation"] = result.get("_explanation", {})
         results.append(item)
     res = {

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -1,7 +1,9 @@
+import asyncio
+
 import pytest
 from elasticsearch import Elasticsearch
 
-from dug.core.async_search import Search
+from dug.core.async_search import Search, SearchException
 from dug.config import Config
 from dug.core.index import Index
 
@@ -88,3 +90,96 @@ def test_init_indices_reuses_existing_indices(real_index):
         # Readable without KeyError -- proves the "already exists" branch
         # completes end-to-end against a real index.
         assert "number_of_replicas" in response[index_name]["settings"]["index"]
+
+
+# Sorting against a real cluster. The mocked unit tests pin the shape of the
+# generated query body; these prove elasticsearch actually accepts it and orders
+# documents the way we claim.
+
+STUDIES = [
+    {"id": "STUDY_LATE", "name": "Late study", "description": "d", "action": "",
+     "element_type": "study", "parents": [], "programs": ["p1"],
+     "metadata": {"Project End Date": "2024-04-30T12:04:00Z"},
+     "tags": [{"category": "Research Network", "value": "zeta"}]},
+    {"id": "STUDY_EARLY", "name": "Early study", "description": "d", "action": "",
+     "element_type": "study", "parents": [], "programs": ["p2"],
+     "metadata": {"Project End Date": "2019-07-15T12:07:00Z"},
+     "tags": [{"category": "Research Network", "value": "alpha"}]},
+    {"id": "STUDY_UNDATED", "name": "Undated study", "description": "d", "action": "",
+     "element_type": "study", "parents": [], "programs": ["p3"],
+     "metadata": {},
+     "tags": [{"category": "Research Network", "value": "mu"}]},
+]
+
+
+@pytest.fixture
+def studies_index(real_index):
+    """Loads the three fixture studies into the disposable studies index."""
+    index_name = real_index.indices["studies_index"]
+    for study in STUDIES:
+        real_index.index_doc(index=index_name, doc=study, doc_id=study["id"])
+    real_index.es.indices.refresh(index=index_name)
+    return index_name
+
+
+def _sorted_ids(index_name, sort, **kwargs):
+    search = Search(cfg=_test_config())
+    try:
+        hits, _total, _aggs = asyncio.run(search.search_elements(
+            index_name, query="study", sort=sort, **kwargs))
+    finally:
+        asyncio.run(search.es.close())
+    return [hit["_source"]["id"] for hit in hits], hits
+
+
+def test_sort_by_project_end_date_desc(studies_index):
+    """Descending date sort, with undated studies last.
+
+    Elasticsearch's own default puts missing values *first* on a descending sort,
+    which would float every undated study to the top -- the opposite of what a
+    'most recently ended' listing means.
+    """
+    ids, hits = _sorted_ids(
+        studies_index, [{"field": "metadata.Project End Date", "order": "desc"}])
+    assert ids == ["STUDY_LATE", "STUDY_EARLY", "STUDY_UNDATED"]
+    # track_scores keeps the relevance signal alive alongside an explicit sort.
+    assert all(hit["_score"] is not None for hit in hits)
+
+
+def test_sort_by_project_end_date_asc(studies_index):
+    "Ascending date sort, still with undated studies last"
+    ids, _hits = _sorted_ids(
+        studies_index, [{"field": "metadata.Project End Date", "order": "asc"}])
+    assert ids == ["STUDY_EARLY", "STUDY_LATE", "STUDY_UNDATED"]
+
+
+def test_sort_on_nested_tag_value(studies_index):
+    "tags is a nested field; sorting on it needs the derived nested path"
+    ids, _hits = _sorted_ids(studies_index, [{"field": "tags.value", "order": "asc"}])
+    assert ids == ["STUDY_EARLY", "STUDY_UNDATED", "STUDY_LATE"]
+
+
+def test_sort_on_multivalued_field_with_mode(studies_index):
+    "mode picks which value of a multi-valued field to sort on"
+    ids, _hits = _sorted_ids(
+        studies_index,
+        [{"field": "programs.keyword", "order": "desc", "mode": "max"}])
+    assert ids == ["STUDY_UNDATED", "STUDY_EARLY", "STUDY_LATE"]
+
+
+def test_sort_on_unmapped_field_raises_search_exception(studies_index):
+    "A bad sort field is the caller's mistake and must name itself in the error"
+    with pytest.raises(SearchException) as excinfo:
+        _sorted_ids(studies_index, [{"field": "no_such_field", "order": "asc"}])
+    assert "no_such_field" in excinfo.value.details
+
+
+def test_sort_on_text_field_raises_search_exception(studies_index):
+    """`name` is mapped as text with no .keyword subfield, so it isn't sortable.
+
+    This is the mistake callers are most likely to make, so the error has to be
+    legible rather than a 500.
+    """
+    with pytest.raises(SearchException) as excinfo:
+        _sorted_ids(studies_index, [{"field": "name", "order": "asc"}])
+    assert "fielddata" in excinfo.value.details.lower()

--- a/tests/unit/test_async_search.py
+++ b/tests/unit/test_async_search.py
@@ -3,11 +3,14 @@
 import asyncio
 import json
 from importlib import reload
+from types import SimpleNamespace
 from unittest import TestCase, mock
+from elasticsearch import ApiError
 from fastapi.testclient import TestClient
 
 from dug.core import async_search
 from dug.config import Config
+from dug.api_models.request_models import SortCriterion
 
 async def _mock_search(*args, **kwargs):
     "Mock of elasticsearch search function. Ignores argument"
@@ -39,6 +42,225 @@ class SearchTestCase(TestCase):
         self.assertIsInstance(concept_types, dict)
         self.assertEqual(len(concept_types), 9)
         self.assertEqual(concept_types['anatomical entity'], 10)
+
+
+def _build_all_query_builders(**kwargs):
+    """Invoke each of the four v2.0 query builders with the same common clauses.
+
+    Returns {builder_name: query_body}. Every builder shares an identical
+    filters/aggs/sort tail, so any assertion about that tail should hold for all
+    four -- this is what keeps the shared-clause helper honest.
+    """
+    search = async_search.Search
+    return {
+        "_get_concepts_query": search._get_concepts_query(
+            query="brain", **kwargs),
+        "get_simple_concept_search_query": search.get_simple_concept_search_query(
+            query="brain", **kwargs),
+        "_get_element_search_query": search._get_element_search_query(
+            concept="", fuzziness=1, prefix_length=3, query="brain",
+            new_model=True, **kwargs),
+        "_get_element_simple_search_query": search._get_element_simple_search_query(
+            concept="", query="brain", new_model=True, **kwargs),
+    }
+
+
+class QueryBuilderCommonClauseTestCase(TestCase):
+    """Pins the filters/aggs/sort tail shared by all four v2.0 query builders."""
+
+    FILTERS = [
+        {"field": "is_cde", "operator": "eq", "value": True},
+        {"field": "metadata", "operator": "size_gt", "value": 2},
+    ]
+    AGGS = {"data_type.keyword": 5, "concept_type": 500}
+
+    def test_filters_and_aggs_tail(self):
+        "filters and aggs produce the same post_filter/runtime_mappings/aggs everywhere"
+        expected_post_filter = {
+            "bool": {
+                "filter": [
+                    {"term": {"is_cde": True}},
+                    {"range": {"metadata_calculated_size": {"gt": 2}}},
+                ]
+            }
+        }
+        expected_aggs = {
+            # 5 is under the limit and passes through; 500 is clamped to 200.
+            "data_type.keyword": {"terms": {"field": "data_type.keyword", "size": 5}},
+            "concept_type": {"terms": {"field": "concept_type", "size": 200}},
+        }
+        bodies = _build_all_query_builders(
+            filters=self.FILTERS, aggs=self.AGGS, aggregate_size_limit=200)
+        for name, body in bodies.items():
+            with self.subTest(builder=name):
+                self.assertEqual(body["post_filter"], expected_post_filter)
+                self.assertEqual(body["aggs"], expected_aggs)
+                self.assertEqual(list(body["runtime_mappings"]),
+                                 ["metadata_calculated_size"])
+                self.assertEqual(
+                    body["runtime_mappings"]["metadata_calculated_size"]["type"], "long")
+
+    def test_no_common_clauses_when_unset(self):
+        "A builder with no filters/aggs/sort emits none of those keys"
+        for name, body in _build_all_query_builders().items():
+            with self.subTest(builder=name):
+                for key in ("post_filter", "runtime_mappings", "aggs", "sort",
+                            "track_scores"):
+                    self.assertNotIn(key, body)
+
+    def test_builders_emit_sort_and_track_scores(self):
+        "sort reaches every builder, and scores stay tracked alongside it"
+        sort = [{"field": "metadata.Project End Date", "order": "desc"}]
+        expected = [
+            {"metadata.Project End Date": {"order": "desc", "missing": "_last"}},
+            {"_score": {"order": "desc"}},
+            {"id.keyword": {"order": "asc"}},
+        ]
+        for name, body in _build_all_query_builders(sort=sort).items():
+            with self.subTest(builder=name):
+                self.assertEqual(body["sort"], expected)
+                self.assertIs(body["track_scores"], True)
+
+
+class ConvertSortToEsTestCase(TestCase):
+    "Unit tests for the SortCriterion -> elasticsearch `sort` translation"
+
+    def _convert(self, sort):
+        return async_search.Search._convert_sort_to_es(sort)
+
+    def test_single_key(self):
+        "A lone descending key gains a _score and an id tiebreaker"
+        self.assertEqual(
+            self._convert([{"field": "metadata.Project End Date", "order": "desc"}]),
+            [
+                {"metadata.Project End Date": {"order": "desc", "missing": "_last"}},
+                {"_score": {"order": "desc"}},
+                {"id.keyword": {"order": "asc"}},
+            ])
+
+    def test_defaults_to_ascending(self):
+        "order is optional and defaults to asc"
+        self.assertEqual(self._convert([{"field": "is_cde"}])[0],
+                         {"is_cde": {"order": "asc", "missing": "_last"}})
+
+    def test_accepts_models_and_dicts(self):
+        "A SortCriterion model and its model_dump() convert identically"
+        criterion = SortCriterion(field="data_type.keyword", order="desc", mode="max")
+        self.assertEqual(self._convert([criterion]),
+                         self._convert([criterion.model_dump()]))
+
+    def test_nested_path_derived_for_tags(self):
+        "tags is mapped as nested, so sorting on it needs an explicit path"
+        self.assertEqual(
+            self._convert([{"field": "tags.value", "order": "asc"}])[0],
+            {"tags.value": {"order": "asc", "missing": "_last",
+                            "nested": {"path": "tags"}}})
+
+    def test_no_nested_path_for_ordinary_fields(self):
+        "A dotted field that isn't nested gets no nested clause"
+        self.assertNotIn("nested",
+                         self._convert([{"field": "data_type.keyword"}])[0]["data_type.keyword"])
+
+    def test_mode_and_missing_passthrough(self):
+        "Explicit mode/missing override the defaults"
+        self.assertEqual(
+            self._convert([{"field": "parents.keyword", "order": "asc",
+                            "mode": "min", "missing": "_first"}])[0],
+            {"parents.keyword": {"order": "asc", "missing": "_first", "mode": "min"}})
+
+    def test_mode_omitted_when_unset(self):
+        "mode is left out entirely rather than sent as null"
+        self.assertNotIn("mode", self._convert([{"field": "is_cde"}])[0]["is_cde"])
+
+    def test_empty_input(self):
+        "None and [] both mean 'no sort'"
+        self.assertEqual(self._convert(None), [])
+        self.assertEqual(self._convert([]), [])
+        self.assertEqual(self._convert([{"field": ""}]), [])
+
+    def test_multi_key_order_preserved(self):
+        "Sort keys are applied in the order given, tiebreakers last"
+        result = self._convert([
+            {"field": "metadata.Project End Date", "order": "desc"},
+            {"field": "data_type.keyword", "order": "asc"},
+        ])
+        self.assertEqual([next(iter(clause)) for clause in result],
+                         ["metadata.Project End Date", "data_type.keyword",
+                          "_score", "id.keyword"])
+
+    def test_tiebreakers_not_duplicated(self):
+        "Explicitly sorting on a tiebreaker field doesn't append it twice"
+        result = self._convert([{"field": "id.keyword", "order": "desc"}])
+        self.assertEqual([next(iter(clause)) for clause in result],
+                         ["id.keyword", "_score"])
+
+    def test_score_sort_carries_no_extras(self):
+        "_score is a metadata field; missing/mode/nested are invalid on it"
+        result = self._convert([{"field": "_score", "order": "asc"}])
+        self.assertEqual(result, [{"_score": {"order": "asc"}},
+                                  {"id.keyword": {"order": "asc"}}])
+
+
+class SearchElementsSortTestCase(TestCase):
+    "Verifies sort survives the trip through search_elements into the ES body"
+
+    def setUp(self):
+        self.search = async_search.Search(Config.from_env())
+        self.captured = {}
+
+        async def _capturing_search(*args, **kwargs):
+            self.captured.update(kwargs)
+            return {"hits": {"total": {"value": 0}, "hits": []}}
+
+        self.search.es = mock.AsyncMock()
+        self.search.es.search = _capturing_search
+
+    def _run(self, **kwargs):
+        asyncio.run(self.search.search_elements(
+            self.search.indices["variables_index"], query="brain", **kwargs))
+        return self.captured["body"]
+
+    def test_sort_reaches_the_query_body(self):
+        "A sort passed to search_elements lands in the elasticsearch body"
+        body = self._run(sort=[{"field": "metadata.Project End Date", "order": "desc"}])
+        self.assertEqual(body["sort"][0],
+                         {"metadata.Project End Date": {"order": "desc",
+                                                        "missing": "_last"}})
+        self.assertIs(body["track_scores"], True)
+
+    def test_no_sort_leaves_body_untouched(self):
+        "Callers that don't sort (e.g. the v1 shims) get the old body verbatim"
+        body = self._run()
+        self.assertNotIn("sort", body)
+        self.assertNotIn("track_scores", body)
+
+    def test_bad_request_becomes_search_exception(self):
+        "An elasticsearch 400 surfaces as SearchException carrying the reason"
+        async def _rejecting_search(*args, **kwargs):
+            raise ApiError(
+                "search_phase_execution_exception",
+                meta=SimpleNamespace(status=400),
+                body={"error": {"root_cause": [
+                    {"reason": "No mapping found for [nope] in order to sort on"}]}},
+            )
+        self.search.es.search = _rejecting_search
+
+        with self.assertRaises(async_search.SearchException) as ctx:
+            asyncio.run(self.search.search_elements(
+                self.search.indices["variables_index"], query="brain",
+                sort=[{"field": "nope"}]))
+        self.assertIn("No mapping found for [nope]", ctx.exception.details)
+
+    def test_server_error_is_not_swallowed(self):
+        "A 5xx is a real server fault and must not be reported as a bad request"
+        async def _failing_search(*args, **kwargs):
+            raise ApiError("boom", meta=SimpleNamespace(status=503), body={})
+        self.search.es.search = _failing_search
+
+        with self.assertRaises(ApiError):
+            asyncio.run(self.search.search_elements(
+                self.search.indices["variables_index"], query="brain"))
+
 
 brain_result_json = """{
   "hits": {

--- a/tests/unit/test_server_v2.py
+++ b/tests/unit/test_server_v2.py
@@ -1,0 +1,137 @@
+"""Unit tests for the v2.0 search endpoints.
+
+`search.search_elements` is stubbed throughout, so these run without elasticsearch.
+"""
+
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dug import server
+from dug.core.async_search import SearchException
+
+V2_ROUTES = ("/concepts", "/variables", "/studies", "/cdes")
+
+# Routes that surface `score` on each result. /studies does not.
+SCORED_ROUTES = ("/concepts", "/variables", "/cdes")
+
+
+@pytest.fixture(name="client")
+def _client():
+    return TestClient(server.APP)
+
+
+def _hit(score=1.0):
+    """A minimal elasticsearch hit that satisfies every v2.0 response model."""
+    return {
+        "_id": "HDP00166",
+        "_score": score,
+        "_explanation": {},
+        "_source": {
+            "id": "HDP00166",
+            "name": "A study",
+            "description": "A description",
+            "action": "https://example.org/HDP00166",
+            "identifiers": [],
+        },
+    }
+
+
+def _stub_search_elements(hits=None, total=1):
+    """Patches search.search_elements, returning the mock so calls can be inspected."""
+    stub = mock.AsyncMock(
+        return_value=(hits if hits is not None else [_hit()], total, {}))
+    return mock.patch.object(server.search, "search_elements", stub), stub
+
+
+def test_sort_is_forwarded_to_search_elements(client):
+    "A sort in the request body reaches search_elements on every v2.0 route"
+    sort = [{"field": "metadata.Project End Date", "order": "desc"}]
+    for route in V2_ROUTES:
+        patcher, stub = _stub_search_elements()
+        with patcher:
+            response = client.post(route, json={"query": "opioid", "sort": sort})
+        assert response.status_code == 200, (route, response.text)
+        # Routes splat the whole request model, so a new field here is only safe
+        # if search_elements accepts a matching keyword argument.
+        assert stub.call_args.kwargs["sort"] == [
+            {"field": "metadata.Project End Date", "order": "desc",
+             "mode": None, "missing": None}
+        ]
+
+
+def test_sort_is_optional(client):
+    "Omitting sort still works and passes an empty list through"
+    for route in V2_ROUTES:
+        patcher, stub = _stub_search_elements()
+        with patcher:
+            response = client.post(route, json={"query": "opioid"})
+        assert response.status_code == 200, (route, response.text)
+        assert stub.call_args.kwargs["sort"] == []
+
+
+def test_null_score_does_not_break_the_response(client):
+    """Elasticsearch returns a null _score when sorting, but `score` is a non-nullable
+    float on every response model, so an unguarded assignment is a 500."""
+    for route in SCORED_ROUTES:
+        patcher, _ = _stub_search_elements(hits=[_hit(score=None)])
+        with patcher:
+            response = client.post(route, json={"query": "opioid"})
+        assert response.status_code == 200, (route, response.text)
+
+    # Only /concepts serializes score back out; the others drop it in
+    # get_response_dict() but still have to validate it.
+    patcher, _ = _stub_search_elements(hits=[_hit(score=None)])
+    with patcher:
+        response = client.post("/concepts", json={"query": "opioid"})
+    assert response.json()["results"][0]["score"] == 0
+
+
+@pytest.mark.parametrize("sort", [
+    [{"field": "name.keyword", "order": "sideways"}],
+    [{"field": "name.keyword", "mode": "stddev"}],
+    [{"field": "name.keyword", "missing": "_middle"}],
+    [{"field": "   "}],
+    [{"field": "_id"}],
+    [{"order": "asc"}],
+    [{"field": f"f{i}"} for i in range(6)],
+])
+def test_invalid_sort_is_rejected(client, sort):
+    "Bad sort input is a validation error, not something elasticsearch has to catch"
+    patcher, stub = _stub_search_elements()
+    with patcher:
+        response = client.post("/studies", json={"query": "opioid", "sort": sort})
+    assert response.status_code == 422, response.text
+    stub.assert_not_called()
+
+
+def test_max_sort_fields_is_allowed(client):
+    "The cap is inclusive"
+    patcher, _ = _stub_search_elements()
+    with patcher:
+        response = client.post("/studies", json={
+            "query": "opioid", "sort": [{"field": f"f{i}"} for i in range(5)]})
+    assert response.status_code == 200, response.text
+
+
+def test_score_and_doc_are_sortable(client):
+    "_score and _doc are the two underscore-prefixed fields that are legal"
+    for field in ("_score", "_doc"):
+        patcher, _ = _stub_search_elements()
+        with patcher:
+            response = client.post("/studies", json={
+                "query": "opioid", "sort": [{"field": field}]})
+        assert response.status_code == 200, (field, response.text)
+
+
+def test_search_exception_returns_400(client):
+    "A query elasticsearch rejects is the caller's fault, not a 500"
+    stub = mock.AsyncMock(side_effect=SearchException(
+        message="Elasticsearch rejected the search request.",
+        details="No mapping found for [nope] in order to sort on"))
+    with mock.patch.object(server.search, "search_elements", stub):
+        response = client.post("/studies", json={
+            "query": "opioid", "sort": [{"field": "nope"}]})
+    assert response.status_code == 400, response.text
+    assert "No mapping found for [nope]" in response.json()["details"]


### PR DESCRIPTION
Sort works in the same way as filters, can be used against arbitrary (sortable) document fields in elasticsearch.